### PR TITLE
Display project of tasks in tasks list

### DIFF
--- a/src/ui/components/tasks_list.rs
+++ b/src/ui/components/tasks_list.rs
@@ -276,7 +276,16 @@ impl TasksList {
         };
         line_spans.push(Span::styled(task.content.clone(), content_style));
 
-        // Due date display (before labels)
+        // Project display
+        if let Some(project) = app.projects.iter().find(|p| p.id == task.project_id) {
+            line_spans.push(Span::raw(" "));
+            line_spans.push(Span::styled(
+                format!("#{}", project.name),
+                Style::default().fg(Color::Cyan),
+            ));
+        }
+
+        // Due date display (after project)
         if let Some(due_date) = &task.due {
             line_spans.push(Span::raw(" "));
             line_spans.push(Span::styled(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tasks now display their associated project as a cyan “#ProjectName” label next to the task content.
- Style
  - Reordered task metadata so the due date appears after the project label for clearer readability.
  - Preserves existing display when a task has no associated project (no project label shown; due date still visible).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->