### PR TITLE
Feature: add a "tomorrow" view

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -113,6 +113,12 @@ impl SyncService {
         storage.get_tasks_for_today().await
     }
 
+    /// Get tasks due tomorrow from local storage (fast)
+    pub async fn get_tasks_for_tomorrow(&self) -> Result<Vec<TaskDisplay>> {
+        let storage = self.storage.lock().await;
+        storage.get_tasks_for_tomorrow().await
+    }
+
     /// Check if sync is currently in progress
     pub async fn is_syncing(&self) -> bool {
         *self.sync_in_progress.lock().await

--- a/src/ui/components/projects_list.rs
+++ b/src/ui/components/projects_list.rs
@@ -37,18 +37,26 @@ impl Sidebar {
             Span::styled(" Today".to_string(), today_style),
         ])));
 
-        // Add separator after Today
+        // Add Tomorrow item after Today
+        let is_tomorrow_selected = matches!(app.sidebar_selection, SidebarSelection::Tomorrow);
+        let tomorrow_style = if is_tomorrow_selected {
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
+        all_items.push(ListItem::new(Line::from(vec![
+            Span::styled(app.icons.today().to_string(), tomorrow_style), // Using same icon as today
+            Span::styled(" Tomorrow".to_string(), tomorrow_style),
+        ])));
+
+        // Add separator after Today and Tomorrow
         all_items.push(ListItem::new(Line::from(vec![Span::styled("", Style::default())])));
 
         // Add labels section header if there are labels
         if !app.labels.is_empty() {
-            // all_items.push(ListItem::new(Line::from(vec![Span::styled(
-            //     format!("{} Labels", app.icons.label()),
-            //     Style::default()
-            //         .fg(Color::Cyan)
-            //         .add_modifier(Modifier::BOLD),
-            // )])));
-
             // Add labels
             for (label_index, label) in app.labels.iter().enumerate() {
                 let is_selected = matches!(app.sidebar_selection, SidebarSelection::Label(idx) if idx == label_index);

--- a/src/ui/components/tasks_list.rs
+++ b/src/ui/components/tasks_list.rs
@@ -24,6 +24,8 @@ impl TasksList {
                 "No projects available. Press 'r' to sync or 'A' to create a project."
             } else if matches!(app.sidebar_selection, super::super::app::SidebarSelection::Today) {
                 "No tasks due today. Press 'a' to create a task or 'r' to sync."
+            } else if matches!(app.sidebar_selection, super::super::app::SidebarSelection::Tomorrow) {
+                "No tasks due tomorrow. Press 'a' to create a task or 'r' to sync."
             } else {
                 "No tasks in this project. Press 'a' to create a task."
             };
@@ -66,6 +68,11 @@ impl TasksList {
         // Handle Today view specially
         if matches!(app.sidebar_selection, super::super::app::SidebarSelection::Today) {
             return Self::create_today_task_items(app, area);
+        }
+
+        // Handle Tomorrow view specially
+        if matches!(app.sidebar_selection, super::super::app::SidebarSelection::Tomorrow) {
+            return Self::create_tomorrow_task_items(app, area);
         }
 
         // Get the current project to filter sections
@@ -204,6 +211,26 @@ impl TasksList {
                 items.push(item);
                 task_index += 1;
             }
+        }
+
+        items
+    }
+
+    /// Create list items for Tomorrow view
+    fn create_tomorrow_task_items(app: &App, _area: ratatui::layout::Rect) -> Vec<ListItem<'_>> {
+        let mut items = Vec::new();
+
+        if app.tasks.is_empty() {
+            return items;
+        }
+
+        // Add tomorrow section header
+        items.push(Self::create_section_header("📅 Tomorrow"));
+
+        // Add all tasks (they're already filtered for tomorrow by the database query)
+        for (task_index, task) in app.tasks.iter().enumerate() {
+            let item = Self::create_task_item(task, task_index, app);
+            items.push(item);
         }
 
         items

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -405,6 +405,9 @@ async fn handle_normal_mode(
                 crate::ui::app::SidebarSelection::Today => {
                     // Cannot edit Today view
                 }
+                crate::ui::app::SidebarSelection::Tomorrow => {
+                    // Cannot edit Tomorrow view
+                }
             }
             Ok(true)
         }
@@ -419,6 +422,9 @@ async fn handle_normal_mode(
                 }
                 crate::ui::app::SidebarSelection::Today => {
                     // Cannot delete Today view
+                }
+                crate::ui::app::SidebarSelection::Tomorrow => {
+                    // Cannot delete Tomorrow view
                 }
             }
             Ok(true)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a Tomorrow view to show tasks due tomorrow; tasks are loaded and presented pre-sorted.

- UI
  - New Tomorrow sidebar item with distinct highlighting and separators.
  - Tasks list shows a “📅 Tomorrow” section header; empty state shows “No tasks due tomorrow.”
  - Navigation updated: Today → Tomorrow → Labels/Projects (and reverse wrapping to Tomorrow).

- Restrictions
  - Editing and deleting are disabled in the Tomorrow view (same as Today).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->