### PR TITLE
Feature: t/T will set a task's due date to today/tomorrow

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -263,6 +263,30 @@ impl SyncService {
         Ok(())
     }
 
+    /// Update task due date
+    pub async fn update_task_due_date(&self, task_id: &str, due_date: Option<&str>) -> Result<()> {
+        // Update task via API using the UpdateTaskArgs structure
+        let task_args = todoist_api::UpdateTaskArgs {
+            content: None,
+            description: None,
+            labels: None,
+            priority: None,
+            due_string: None,
+            due_date: due_date.map(std::string::ToString::to_string),
+            due_datetime: None,
+            due_lang: None,
+            deadline_date: None,
+            deadline_lang: None,
+            assignee_id: None,
+            duration: None,
+            duration_unit: None,
+        };
+        let _task = self.todoist.update_task(task_id, &task_args).await?;
+
+        // The UI will handle the sync separately to ensure proper error handling
+        Ok(())
+    }
+
     /// Delete a project
     pub async fn delete_project(&self, project_id: &str) -> Result<()> {
         // Delete project via API

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -434,6 +434,16 @@ async fn handle_normal_mode(
             app.icons.cycle_icon_theme();
             Ok(true)
         }
+        KeyCode::Char('t') => {
+            // Set selected task due date to today
+            app.set_selected_task_due_today(sync_service).await;
+            Ok(true)
+        }
+        KeyCode::Char('T') => {
+            // Set selected task due date to tomorrow
+            app.set_selected_task_due_tomorrow(sync_service).await;
+            Ok(true)
+        }
         _ => Ok(false),
     }
 }


### PR DESCRIPTION
As this is synchronous, the UI hangs until the call to todoist API is completed. This is not ideal, but at least we can do this with terminalist. I will probably change the code architecture soon anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Quickly set the selected task’s due date to today or tomorrow using keyboard shortcuts: t (today) and T (tomorrow).
  - Updates only the due date without altering other task details.
  - Displays clear success and error messages, with automatic sync attempts and task list refresh to keep data current.
- Bug Fixes
  - Improved handling when no task is selected or a task is deleted, preventing unintended actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->