### PR TITLE
Feature: w/W shortcuts for set task to next week / next week end

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Once the application is running, you can use these keyboard shortcuts:
 - **`Space`** or **`Enter`** Toggle task completion (complete ↔ reopen)
 - **`a`** Create new task
 - **`d`** Delete selected task (with confirmation)
+- **`t`** Set task due date to today
+- **`T`** Set task due date to tomorrow
+- **`w`** Set task due date to next week (Monday)
+- **`W`** Set task due date to next week end (Saturday)
 
 ### **Project Management**
 - **`A`** Create new project

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -393,6 +393,10 @@ Terminalist is a high-performance terminal user interface (TUI) application for 
 - `Space/Enter`: Toggle task completion
 - `a`: Create new task
 - `d`: Delete selected task
+- `t`: Set task due date to today
+- `T`: Set task due date to tomorrow
+- `w`: Set task due date to next week (Monday)
+- `W`: Set task due date to next week end (Saturday)
 
 #### Project Management
 - `A`: Create new project

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -4,9 +4,14 @@ use crate::debug_logger::DebugLogger;
 use crate::icons::IconService;
 use crate::sync::{SyncService, SyncStats, SyncStatus};
 use crate::todoist::{LabelDisplay, ProjectDisplay, SectionDisplay, TaskDisplay};
-use chrono::{Datelike, Duration, Utc};
+use chrono::{Datelike, Duration, NaiveDate, Utc};
 use ratatui::widgets::ListState;
 use tokio::task::JoinHandle;
+
+/// Format a NaiveDate to YYYY-MM-DD string
+fn format_ymd(d: NaiveDate) -> String {
+    d.format("%Y-%m-%d").to_string()
+}
 
 /// Represents the currently selected item in the sidebar
 #[derive(Debug, Clone, PartialEq)]
@@ -727,7 +732,7 @@ impl App {
             self.error_message = None;
             self.info_message = None;
 
-            let today = Utc::now().date_naive().format("%Y-%m-%d").to_string();
+            let today = format_ymd(Utc::now().date_naive());
 
             match sync_service
                 .update_task_due_date(&task.id, Some(&today))
@@ -773,9 +778,7 @@ impl App {
             self.error_message = None;
             self.info_message = None;
 
-            let tomorrow = (Utc::now().date_naive() + Duration::days(1))
-                .format("%Y-%m-%d")
-                .to_string();
+            let tomorrow = format_ymd(Utc::now().date_naive() + Duration::days(1));
 
             match sync_service
                 .update_task_due_date(&task.id, Some(&tomorrow))

--- a/src/ui/components/help_panel.rs
+++ b/src/ui/components/help_panel.rs
@@ -54,6 +54,10 @@ Space       Toggle task completion
 a           Create new task
 e           Edit selected task
 d           Delete task (with confirmation)
+t           Set task due date to today
+T           Set task due date to tomorrow
+w           Set task due date to next week (Monday)
+W           Set task due date to next week end (Saturday)
 
 SYNC & DATA
 -----------

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -444,6 +444,18 @@ async fn handle_normal_mode(
             app.set_selected_task_due_tomorrow(sync_service).await;
             Ok(true)
         }
+        KeyCode::Char('w') => {
+            // Set selected task due date to next week Monday
+            app.set_selected_task_due_next_week_monday(sync_service)
+                .await;
+            Ok(true)
+        }
+        KeyCode::Char('W') => {
+            // Set selected task due date to next week Saturday
+            app.set_selected_task_due_next_week_saturday(sync_service)
+                .await;
+            Ok(true)
+        }
         _ => Ok(false),
     }
 }


### PR DESCRIPTION
As this is synchronous, the UI hangs until the call to todoist API is completed. This is not ideal, but at least we can do this with terminalist. I will probably change the code architecture soon anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for setting task due dates: t (today), T (tomorrow), w (next week — Monday), W (next week end — Saturday).

* **Documentation**
  * Updated README and PRD with the new Task Management shortcuts.
  * In-app help panel now shows the new shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->