### PR TITLE
Adding a task pre-selects the current project as task's project

### DIFF
--- a/src/ui/components/dialog_component.rs
+++ b/src/ui/components/dialog_component.rs
@@ -534,10 +534,11 @@ impl Component for DialogComponent {
                     DialogType::TaskCreation { default_project_id } => {
                         self.input_buffer.clear();
                         self.cursor_position = 0;
-                        // Set the selected project index if a default project is provided
+                        // Set the selected task project index if a default project is provided
                         if let Some(project_id) = default_project_id {
-                            if let Some(index) = self.projects.iter().position(|p| &p.id == project_id) {
-                                self.selected_project_index = index;
+                            let task_projects = self.get_task_projects();
+                            if let Some(index) = task_projects.iter().position(|p| &p.id == project_id) {
+                                self.selected_task_project_index = Some(index);
                             }
                         }
                     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects default project preselection in the task creation dialog to use the task-specific project list.
  * Ensures the intended project is highlighted when a default project is set, preventing mismatches.
  * Maintains existing input clearing and cursor reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->