### PR TITLE
Remove migration mechanism, it's useless for this project

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -215,7 +215,6 @@ impl LocalStorage {
 
         let storage = LocalStorage { pool, _anchor: anchor };
         storage.init_schema().await?;
-        storage.run_migrations().await?;
         storage.start_keepalive_task();
 
         Ok(storage)
@@ -1102,24 +1101,6 @@ impl LocalStorage {
             .await?;
 
         tx.commit().await?;
-        Ok(())
-    }
-
-    async fn run_migrations(&self) -> Result<()> {
-        // Check if parent_id column exists in projects table
-        let has_parent_id = sqlx::query_scalar::<_, Option<String>>(
-            "SELECT name FROM pragma_table_info('projects') WHERE name = 'parent_id'",
-        )
-        .fetch_optional(&self.pool)
-        .await?
-        .is_some();
-
-        if !has_parent_id {
-            sqlx::query("ALTER TABLE projects ADD COLUMN parent_id TEXT")
-                .execute(&self.pool)
-                .await?;
-        }
-
         Ok(())
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined startup by removing an internal migration step now covered by schema initialization, reducing overhead at launch.
  * Retired background migration logic from the startup path to lower complexity and potential delays.
  * No user-facing changes; existing data remains compatible.
  * Public APIs remain unchanged; no configuration or action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->