### PR TITLE
Feat: add `Upcoming` view

### DIFF
--- a/src/icons.rs
+++ b/src/icons.rs
@@ -289,4 +289,13 @@ impl IconService {
             IconTheme::Ascii => "+",
         }
     }
+
+    #[must_use]
+    pub fn upcoming(&self) -> &'static str {
+        match self.current_theme {
+            IconTheme::Emoji => "📊",
+            IconTheme::Unicode => "◎",
+            IconTheme::Ascii => ">",
+        }
+    }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -119,6 +119,12 @@ impl SyncService {
         storage.get_tasks_for_tomorrow().await
     }
 
+    /// Get tasks for upcoming from local storage (fast)
+    pub async fn get_tasks_for_upcoming(&self) -> Result<Vec<TaskDisplay>> {
+        let storage = self.storage.lock().await;
+        storage.get_tasks_for_upcoming().await
+    }
+
     /// Check if sync is currently in progress
     pub async fn is_syncing(&self) -> bool {
         *self.sync_in_progress.lock().await

--- a/src/ui/app_component.rs
+++ b/src/ui/app_component.rs
@@ -228,6 +228,11 @@ impl AppComponent {
                             .log("Global key: 'D' - cannot delete Tomorrow view".to_string());
                         Action::ShowDialog(DialogType::Info("Cannot delete the Tomorrow view".to_string()))
                     }
+                    SidebarSelection::Upcoming => {
+                        self.debug_logger
+                            .log("Global key: 'D' - cannot delete Upcoming view".to_string());
+                        Action::ShowDialog(DialogType::Info("Cannot delete the Upcoming view".to_string()))
+                    }
                     SidebarSelection::Label(index) => {
                         if let Some(label) = self.state.labels.get(*index) {
                             self.debug_logger.log(format!(
@@ -274,6 +279,11 @@ impl AppComponent {
                         self.debug_logger
                             .log("Global key: 'E' - cannot edit Tomorrow view".to_string());
                         Action::ShowDialog(DialogType::Info("Cannot edit the Tomorrow view".to_string()))
+                    }
+                    SidebarSelection::Upcoming => {
+                        self.debug_logger
+                            .log("Global key: 'E' - cannot edit Upcoming view".to_string());
+                        Action::ShowDialog(DialogType::Info("Cannot edit the Upcoming view".to_string()))
                     }
                     SidebarSelection::Label(index) => {
                         if let Some(label) = self.state.labels.get(*index) {
@@ -371,6 +381,7 @@ impl AppComponent {
                 let selection_desc = match &selection {
                     SidebarSelection::Today => "Today".to_string(),
                     SidebarSelection::Tomorrow => "Tomorrow".to_string(),
+                    SidebarSelection::Upcoming => "Upcoming".to_string(),
                     SidebarSelection::Project(index) => {
                         if let Some(project) = self.state.projects.get(*index) {
                             format!("Project({}) '{}'", index, project.name)
@@ -594,6 +605,7 @@ impl AppComponent {
                 let selection_context = match &self.state.sidebar_selection {
                     SidebarSelection::Today => "Today view".to_string(),
                     SidebarSelection::Tomorrow => "Tomorrow view".to_string(),
+                    SidebarSelection::Upcoming => "Upcoming view".to_string(),
                     SidebarSelection::Project(index) => {
                         if let Some(project) = projects.get(*index) {
                             format!("Project '{}'", project.name)

--- a/src/ui/components/sidebar_component.rs
+++ b/src/ui/components/sidebar_component.rs
@@ -46,7 +46,8 @@ impl SidebarComponent {
     fn get_next_selection(&self) -> SidebarSelection {
         match &self.selection {
             SidebarSelection::Today => SidebarSelection::Tomorrow,
-            SidebarSelection::Tomorrow => {
+            SidebarSelection::Tomorrow => SidebarSelection::Upcoming,
+            SidebarSelection::Upcoming => {
                 if !self.labels.is_empty() {
                     SidebarSelection::Label(0)
                 } else if !self.projects.is_empty() {
@@ -115,11 +116,12 @@ impl SidebarComponent {
                 }
             }
             SidebarSelection::Tomorrow => SidebarSelection::Today,
+            SidebarSelection::Upcoming => SidebarSelection::Tomorrow,
             SidebarSelection::Label(index) => {
                 if *index > 0 {
                     SidebarSelection::Label(index - 1)
                 } else {
-                    SidebarSelection::Tomorrow
+                    SidebarSelection::Upcoming
                 }
             }
             SidebarSelection::Project(index) => {
@@ -137,7 +139,7 @@ impl SidebarComponent {
                     } else if !self.labels.is_empty() {
                         SidebarSelection::Label(self.labels.len() - 1)
                     } else {
-                        SidebarSelection::Tomorrow
+                        SidebarSelection::Upcoming
                     }
                 } else {
                     SidebarSelection::Today
@@ -220,13 +222,16 @@ impl SidebarComponent {
         if index == 1 {
             return SidebarSelection::Tomorrow;
         }
-
-        let label_count = self.labels.len();
-        if index < 2 + label_count {
-            return SidebarSelection::Label(index - 2);
+        if index == 2 {
+            return SidebarSelection::Upcoming;
         }
 
-        let project_index = index - 2 - label_count;
+        let label_count = self.labels.len();
+        if index < 3 + label_count {
+            return SidebarSelection::Label(index - 3);
+        }
+
+        let project_index = index - 3 - label_count;
         let sorted_projects = self.get_sorted_projects();
         if let Some((original_index, _)) = sorted_projects.get(project_index) {
             SidebarSelection::Project(*original_index)
@@ -320,6 +325,21 @@ impl Component for SidebarComponent {
         all_items.push(ListItem::new(Line::from(vec![
             Span::styled(self.icons.tomorrow().to_string(), tomorrow_style),
             Span::styled("Tomorrow".to_string(), tomorrow_style),
+        ])));
+
+        // Add Upcoming item
+        let is_upcoming_selected = matches!(self.selection, SidebarSelection::Upcoming);
+        let upcoming_style = if is_upcoming_selected {
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
+        all_items.push(ListItem::new(Line::from(vec![
+            Span::styled(self.icons.upcoming().to_string(), upcoming_style),
+            Span::styled("Upcoming".to_string(), upcoming_style),
         ])));
 
         // Add labels

--- a/src/ui/core/actions.rs
+++ b/src/ui/core/actions.rs
@@ -6,6 +6,7 @@ pub enum SidebarSelection {
     #[default]
     Today, // Today view (special view)
     Tomorrow,       // Tomorrow view (special view)
+    Upcoming,       // Upcoming view (tasks with future due dates)
     Label(usize),   // Index into labels vector
     Project(usize), // Index into projects vector
 }

--- a/src/ui/core/task_manager.rs
+++ b/src/ui/core/task_manager.rs
@@ -201,6 +201,10 @@ impl TaskManager {
                             .get_tasks_for_tomorrow()
                             .await
                             .unwrap_or_default(),
+                        SidebarSelection::Upcoming => sync_service
+                            .get_tasks_for_upcoming()
+                            .await
+                            .unwrap_or_default(),
                         SidebarSelection::Project(index) => {
                             if let Some(project) = projects.get(index) {
                                 sync_service


### PR DESCRIPTION
while here, fixed the tomorrow's view broken header handling

note : this is getting out of hands, we need to find a better way to handle sections and so on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  - Added an Upcoming view to the sidebar with a dedicated icon and selection highlighting.
  - Updated navigation: Today → Tomorrow → Upcoming, with mouse and keyboard support.
  - Upcoming tasks are grouped into sections (Overdue, Today, Tomorrow, Day After Tomorrow, and future dates) with clear headers.
  - Displayed message when no upcoming tasks are scheduled.
  - Disabled delete/edit shortcuts in Upcoming with explanatory notifications.
  - Faster loading of upcoming tasks via local data access for a more responsive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->