### PR TITLE
feat: add foreign key constraints and indexes to tasks table

### DIFF
--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -98,7 +98,9 @@ impl LocalStorage {
                 is_recurring BOOLEAN NOT NULL DEFAULT 0,
                 deadline TEXT,
                 duration TEXT,
-                FOREIGN KEY (parent_id) REFERENCES tasks(id) ON DELETE CASCADE
+                FOREIGN KEY (parent_id) REFERENCES tasks(id) ON DELETE CASCADE,
+                FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+                FOREIGN KEY (section_id) REFERENCES sections(id) ON DELETE SET NULL
             )
             ",
         )
@@ -141,6 +143,19 @@ impl LocalStorage {
             .await?;
 
         sqlx::query("CREATE INDEX IF NOT EXISTS idx_task_labels_label_id ON task_labels(label_id)")
+            .execute(&self.pool)
+            .await?;
+
+        // Create indexes for tasks table
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_tasks_project_id ON tasks(project_id)")
+            .execute(&self.pool)
+            .await?;
+
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_tasks_section_id ON tasks(section_id)")
+            .execute(&self.pool)
+            .await?;
+
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_tasks_parent_id ON tasks(parent_id)")
             .execute(&self.pool)
             .await?;
 


### PR DESCRIPTION
Fixes #44

## Description

Add missing foreign key constraints and indexes to the tasks table to improve data integrity and query performance.

## Changes

- Add foreign key constraint for `project_id` with `ON DELETE CASCADE`
- Add foreign key constraint for `section_id` with `ON DELETE SET NULL`
- Add index on `project_id` for project-based task retrieval
- Add index on `section_id` for section-based task retrieval
- Add index on `parent_id` for hierarchical task queries

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deleting a project now automatically removes its associated tasks, keeping workspaces tidy.
  * Deleting a section no longer deletes its tasks; they remain and are unassigned from that section.
  * Task navigation, filtering, and parent/child operations are faster and more responsive thanks to backend indexing improvements, especially in projects and sections with many tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->