### PR TITLE
feat: add debug mode for SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Thumbs.db
 # Environment variables
 .env
 .env.local
+
+# Debug database
+terminalist_debug.db

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ async fn main() -> Result<()> {
     // Parse command line arguments
     let args: Vec<String> = env::args().collect();
     let show_help = args.iter().any(|arg| arg == "--help" || arg == "-h");
+    let debug_mode = args.iter().any(|arg| arg == "--debug" || arg == "-d");
 
     if show_help {
         println!("Terminalist - A TUI for Todoist");
@@ -23,6 +24,7 @@ async fn main() -> Result<()> {
         println!();
         println!("OPTIONS:");
         println!("    -h, --help    Show this help message");
+        println!("    -d, --debug   Use file-backed SQLite database for debugging");
         println!();
         println!("ENVIRONMENT VARIABLES:");
         println!("    TODOIST_API_TOKEN    Your Todoist API token (required)");
@@ -44,7 +46,12 @@ async fn main() -> Result<()> {
     // Create sync service with timeout
     let api_token = std::env::var("TODOIST_API_TOKEN")?;
 
-    match tokio::time::timeout(tokio::time::Duration::from_secs(10), sync::SyncService::new(api_token)).await {
+    match tokio::time::timeout(
+        tokio::time::Duration::from_secs(10),
+        sync::SyncService::new(api_token, debug_mode),
+    )
+    .await
+    {
         Ok(Ok(sync_service)) => {
             ui::run_app(sync_service).await?;
         }

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -13,8 +13,18 @@ pub struct LocalStorage {
 
 impl LocalStorage {
     /// Initialize the local storage with `SQLite` database
-    pub async fn new() -> Result<Self> {
-        let database_url = "sqlite:file:terminalist_memdb?mode=memory&cache=shared".to_string();
+    pub async fn new(debug_mode: bool) -> Result<Self> {
+        let database_url = if debug_mode {
+            // File-backed database for debugging - ensure file exists
+            let db_path = "terminalist_debug.db";
+            if !std::path::Path::new(db_path).exists() {
+                std::fs::File::create(db_path)?;
+            }
+            format!("sqlite:{}", db_path)
+        } else {
+            // In-memory database for normal operation
+            "sqlite:file:terminalist_memdb?mode=memory&cache=shared".to_string()
+        };
 
         // Configure SQLite connection options with foreign keys enabled
         let connect_options = SqliteConnectOptions::from_str(&database_url)?.foreign_keys(true);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -25,9 +25,9 @@ pub enum SyncStatus {
 
 impl SyncService {
     /// Create a new sync service
-    pub async fn new(api_token: String) -> Result<Self> {
+    pub async fn new(api_token: String, debug_mode: bool) -> Result<Self> {
         let todoist = TodoistWrapper::new(api_token);
-        let storage = Arc::new(Mutex::new(LocalStorage::new().await?));
+        let storage = Arc::new(Mutex::new(LocalStorage::new(debug_mode).await?));
         let sync_in_progress = Arc::new(Mutex::new(false));
 
         Ok(Self {


### PR DESCRIPTION
- Introduced a debug mode that allows the use of a file-backed SQLite database for debugging purposes.
- Updated the `SyncService` and `LocalStorage` constructors to accept a `debug_mode` parameter.
- Modified the `.gitignore` to include the new debug database file `terminalist_debug.db`.
- Enhanced command line options to include a `--debug` flag for enabling debug mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a --debug (-d) CLI flag to enable a persistent local database for troubleshooting; default mode continues using in-memory storage.
  * Updated help/usage text to include the new debug option.
* **Chores**
  * Excluded the generated debug database file (terminalist_debug.db) from version control.

No other behavior changes to syncing or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->