### PR TITLE
Use local time instead of UTC

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -176,7 +176,7 @@ impl Config {
         // Add header comment
         let header = format!(
             "# Terminalist Configuration File\n# Generated on {}\n\n",
-            chrono::Utc::now().format("%Y-%m-%d")
+            chrono::Local::now().format("%Y-%m-%d")
         );
 
         let full_content = header + &toml_content;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -139,7 +139,7 @@ impl SyncService {
     /// Get tasks for "Today" view (UI business logic: overdue + today)
     pub async fn get_tasks_for_today(&self) -> Result<Vec<TaskDisplay>> {
         let storage = self.storage.lock().await;
-        let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
 
         let overdue_tasks = storage.get_overdue_tasks().await?;
         let today_tasks = storage.get_tasks_due_on(&today).await?;
@@ -153,7 +153,9 @@ impl SyncService {
     /// Get tasks for "Tomorrow" view (pure tomorrow tasks)
     pub async fn get_tasks_for_tomorrow(&self) -> Result<Vec<TaskDisplay>> {
         let storage = self.storage.lock().await;
-        let tomorrow = (chrono::Utc::now() + chrono::Duration::days(1)).format("%Y-%m-%d").to_string();
+        let tomorrow = (chrono::Local::now() + chrono::Duration::days(1))
+            .format("%Y-%m-%d")
+            .to_string();
 
         storage.get_tasks_due_on(&tomorrow).await
     }
@@ -161,8 +163,10 @@ impl SyncService {
     /// Get tasks for "Upcoming" view (UI business logic: overdue + today + next 3 months)
     pub async fn get_tasks_for_upcoming(&self) -> Result<Vec<TaskDisplay>> {
         let storage = self.storage.lock().await;
-        let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
-        let three_months_later = (chrono::Utc::now() + chrono::Duration::days(90)).format("%Y-%m-%d").to_string();
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        let three_months_later = (chrono::Local::now() + chrono::Duration::days(90))
+            .format("%Y-%m-%d")
+            .to_string();
 
         let overdue_tasks = storage.get_overdue_tasks().await?;
         let today_tasks = storage.get_tasks_due_on(&today).await?;

--- a/src/ui/app_component.rs
+++ b/src/ui/app_component.rs
@@ -781,7 +781,7 @@ impl AppComponent {
                     "Set task due today" => {
                         // task_info format: "task_id|today"
                         if let Some((task_id, _)) = task_info.split_once('|') {
-                            let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+                            let today = chrono::Local::now().format("%Y-%m-%d").to_string();
                             match sync_service.update_task_due_date(task_id, Some(&today)).await {
                                 Ok(()) => Ok(format!("✅ Task due date set to today: {}", task_id)),
                                 Err(e) => Err(format!("❌ Failed to set task due date: {}", e)),
@@ -793,8 +793,9 @@ impl AppComponent {
                     "Set task due tomorrow" => {
                         // task_info format: "task_id|tomorrow"
                         if let Some((task_id, _)) = task_info.split_once('|') {
-                            let tomorrow =
-                                (chrono::Utc::now() + chrono::Duration::days(1)).format("%Y-%m-%d").to_string();
+                            let tomorrow = (chrono::Local::now() + chrono::Duration::days(1))
+                                .format("%Y-%m-%d")
+                                .to_string();
                             match sync_service.update_task_due_date(task_id, Some(&tomorrow)).await {
                                 Ok(()) => Ok(format!("✅ Task due date set to tomorrow: {}", task_id)),
                                 Err(e) => Err(format!("❌ Failed to set task due date: {}", e)),
@@ -806,7 +807,7 @@ impl AppComponent {
                     "Set task due next week" => {
                         // task_info format: "task_id|next_week"
                         if let Some((task_id, _)) = task_info.split_once('|') {
-                            let today = chrono::Utc::now().date_naive();
+                            let today = chrono::Local::now().date_naive();
                             let next_monday = crate::utils::datetime::next_weekday(today, chrono::Weekday::Mon);
                             let next_monday_str = crate::utils::datetime::format_ymd(next_monday);
                             match sync_service.update_task_due_date(task_id, Some(&next_monday_str)).await {
@@ -820,7 +821,7 @@ impl AppComponent {
                     "Set task due weekend" => {
                         // task_info format: "task_id|weekend"
                         if let Some((task_id, _)) = task_info.split_once('|') {
-                            let today = chrono::Utc::now().date_naive();
+                            let today = chrono::Local::now().date_naive();
                             let next_saturday = crate::utils::datetime::next_weekday(today, chrono::Weekday::Sat);
                             let next_saturday_str = crate::utils::datetime::format_ymd(next_saturday);
                             match sync_service.update_task_due_date(task_id, Some(&next_saturday_str)).await {

--- a/src/ui/components/task_list_component.rs
+++ b/src/ui/components/task_list_component.rs
@@ -111,7 +111,7 @@ impl TaskListComponent {
     fn build_today_items(&mut self) {
         use crate::ui::components::task_list_item_component::{HeaderItem, SeparatorItem};
 
-        let now = chrono::Utc::now().date_naive();
+        let now = chrono::Local::now().date_naive();
         let mut overdue_tasks = Vec::new();
         let mut today_tasks = Vec::new();
 
@@ -196,7 +196,7 @@ impl TaskListComponent {
         use crate::ui::components::task_list_item_component::{HeaderItem, SeparatorItem};
         use std::collections::BTreeMap;
 
-        let today = chrono::Utc::now().date_naive();
+        let today = chrono::Local::now().date_naive();
         let mut overdue_tasks = Vec::new();
         let mut future_tasks_by_date: BTreeMap<chrono::NaiveDate, Vec<TaskDisplay>> = BTreeMap::new();
 


### PR DESCRIPTION
closes #71


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * All date calculations now use your local timezone instead of UTC, so “Today,” “Tomorrow,” “Upcoming,” weekend, and next‑week actions align with your local date.
  * Task grouping and overdue status in lists reflect local time for accurate categorization.
  * Generated configuration files now show the creation timestamp in your local time for clearer context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->