### PR TITLE
enhance: change sidebar width unit from percentage to columns count

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,8 +11,8 @@ indent_style = space
 indent_size = 4
 
 [*.md]
-max_line_length = off
-trim_trailing_whitespace = false
+max_line_length = 80
+trim_trailing_whitespace = true
 
 [*.yml]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_size = 4
 
 [*.md]
 max_line_length = 80
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false
 
 [*.yml]
 indent_style = space

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ pub struct UiConfig {
     pub default_project: String,
     /// Enable mouse support
     pub mouse_enabled: bool,
-    /// Sidebar width percentage (10-40)
+    /// Sidebar width in columns (15-50)
     pub sidebar_width: u16,
 }
 
@@ -70,7 +70,7 @@ impl Default for UiConfig {
         Self {
             default_project: "today".to_string(),
             mouse_enabled: true,
-            sidebar_width: 25,
+            sidebar_width: 30,
         }
     }
 }
@@ -142,8 +142,11 @@ impl Config {
     /// Validate configuration values
     pub fn validate(&self) -> Result<()> {
         // Validate UI settings
-        if self.ui.sidebar_width < 10 || self.ui.sidebar_width > 40 {
-            anyhow::bail!("sidebar_width must be between 10 and 40, got {}", self.ui.sidebar_width);
+        if self.ui.sidebar_width < 15 || self.ui.sidebar_width > 50 {
+            anyhow::bail!(
+                "sidebar_width must be between 15 and 50 columns, got {}",
+                self.ui.sidebar_width
+            );
         }
 
         // Validate default project

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 //!
 //! This module handles loading, parsing, and validation of configuration files.
 
-use crate::constants::CONFIG_GENERATED;
+use crate::constants::{CONFIG_GENERATED, SIDEBAR_DEFAULT_WIDTH, SIDEBAR_MAX_WIDTH, SIDEBAR_MIN_WIDTH};
 use crate::utils::datetime;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ pub struct UiConfig {
     pub default_project: String,
     /// Enable mouse support
     pub mouse_enabled: bool,
-    /// Sidebar width in columns (15-50)
+    /// Sidebar width in columns
     pub sidebar_width: u16,
 }
 
@@ -70,7 +70,7 @@ impl Default for UiConfig {
         Self {
             default_project: "today".to_string(),
             mouse_enabled: true,
-            sidebar_width: 30,
+            sidebar_width: SIDEBAR_DEFAULT_WIDTH,
         }
     }
 }
@@ -142,9 +142,11 @@ impl Config {
     /// Validate configuration values
     pub fn validate(&self) -> Result<()> {
         // Validate UI settings
-        if self.ui.sidebar_width < 15 || self.ui.sidebar_width > 50 {
+        if self.ui.sidebar_width < SIDEBAR_MIN_WIDTH || self.ui.sidebar_width > SIDEBAR_MAX_WIDTH {
             anyhow::bail!(
-                "sidebar_width must be between 15 and 50 columns, got {}",
+                "sidebar_width must be between {} and {} columns, got {}",
+                SIDEBAR_MIN_WIDTH,
+                SIDEBAR_MAX_WIDTH,
                 self.ui.sidebar_width
             );
         }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -74,3 +74,13 @@ pub const DIALOG_TITLE_DEBUG_LOGS: &str = "🔍 Debug Logs - Press 'Esc', 'G' or
 
 // Date header format for upcoming view
 pub const UPCOMING_DATE_FORMAT: &str = "📊 {} - {}";
+
+// UI Layout Constants
+/// Minimum sidebar width in columns
+pub const SIDEBAR_MIN_WIDTH: u16 = 15;
+/// Maximum sidebar width in columns
+pub const SIDEBAR_MAX_WIDTH: u16 = 50;
+/// Default sidebar width in columns
+pub const SIDEBAR_DEFAULT_WIDTH: u16 = 30;
+/// Minimum main area width to preserve usability
+pub const MAIN_AREA_MIN_WIDTH: u16 = 20;

--- a/src/ui/app_component.rs
+++ b/src/ui/app_component.rs
@@ -1083,13 +1083,12 @@ impl AppComponent {
 }
 
 impl AppComponent {
-    /// Calculate sidebar width based on percentage of screen width
+    /// Calculate sidebar width based on configured columns
     fn calculate_sidebar_width(&self, screen_width: u16) -> u16 {
-        let sidebar_percentage = self.config.ui.sidebar_width.min(100); // Cap at 100%
-        let sidebar_width_calc = ((screen_width as u32).saturating_mul(sidebar_percentage as u32) / 100) as u16;
+        let sidebar_columns = self.config.ui.sidebar_width;
         let min_main_area = 20u16;
         let max_sidebar_width = screen_width.saturating_sub(min_main_area);
-        sidebar_width_calc.min(max_sidebar_width)
+        sidebar_columns.min(max_sidebar_width)
     }
 }
 

--- a/src/ui/app_component.rs
+++ b/src/ui/app_component.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::constants::MAIN_AREA_MIN_WIDTH;
 use crate::constants::*;
 use crate::logger::Logger;
 use crate::sync::{SyncService, SyncStatus};
@@ -1086,8 +1087,7 @@ impl AppComponent {
     /// Calculate sidebar width based on configured columns
     fn calculate_sidebar_width(&self, screen_width: u16) -> u16 {
         let sidebar_columns = self.config.ui.sidebar_width;
-        let min_main_area = 20u16;
-        let max_sidebar_width = screen_width.saturating_sub(min_main_area);
+        let max_sidebar_width = screen_width.saturating_sub(MAIN_AREA_MIN_WIDTH);
         sidebar_columns.min(max_sidebar_width)
     }
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -19,11 +19,11 @@ fn test_config_validation() {
     assert!(config.validate().is_ok());
 
     // Invalid sidebar width should fail
-    config.ui.sidebar_width = 5;
+    config.ui.sidebar_width = 10;
     assert!(config.validate().is_err());
 
     // Reset and test invalid sync interval
-    config.ui.sidebar_width = 25;
+    config.ui.sidebar_width = 35;
     config.sync.auto_sync_interval_minutes = 2000;
     assert!(config.validate().is_err());
 }
@@ -41,7 +41,7 @@ fn test_partial_config_deserialization() {
     // Test that partial TOML configs merge with defaults
     let partial_toml = r#"
 [ui]
-sidebar_width = 30
+sidebar_width = 35
 
 [logging]
 enabled = true
@@ -50,7 +50,7 @@ enabled = true
     let config: Config = toml::from_str(partial_toml).unwrap();
 
     // Check that specified values are used
-    assert_eq!(config.ui.sidebar_width, 30);
+    assert_eq!(config.ui.sidebar_width, 35);
     assert!(config.logging.enabled);
 
     // Check that unspecified values use defaults


### PR DESCRIPTION
fixes #81 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Sidebar now uses column-based sizing instead of a percentage for more consistent widths across screens.
- Defaults & Validation
  - Default sidebar width set to 30 columns; valid range updated to 15–50 columns with clearer validation messages and bounds.
- Documentation
  - Guidance updated to reflect column-based sidebar sizing and constraints.
- Tests
  - Adjusted tests to align with new default and validation boundaries.
- Chores
  - Markdown rules: wrap at 80 characters and trim trailing whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->