### PR TITLE
Get rid of useless confirmation dialog when something succeeds

### DIFF
--- a/src/ui/core/task_manager.rs
+++ b/src/ui/core/task_manager.rs
@@ -115,8 +115,6 @@ impl TaskManager {
                         let _ = action_sender.send(Action::NavigateToSidebar(SidebarSelection::Today));
                     }
 
-                    // Show success message
-                    let _ = action_sender.send(Action::ShowDialog(crate::ui::core::actions::DialogType::Info(message)));
                     Ok(result)
                 }
                 Err(e) => {


### PR DESCRIPTION
closes #94 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined post-task experience by removing the success confirmation dialog after background operations complete.
  * On successful completion, the app now silently proceeds with the existing refresh/navigation flow, reducing interruptions and improving workflow continuity.
  * Error handling remains unchanged; users will still be notified of failures as before.
  * No impact on data flow or other UI behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->