### PR TITLE
Refactor: use our own uuids as PK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,6 +2223,7 @@ dependencies = [
  "todoist-api",
  "tokio",
  "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -2522,7 +2523,9 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
+ "getrandom 0.3.3",
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ dirs = "6.0"
 log = "0.4"
 fern = "0.7"
 once_cell = "1.19"
+uuid = { version = "1.11", features = ["v4", "serde"] }

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -68,13 +68,14 @@ impl LocalStorage {
         sqlx::query(
             r"
             CREATE TABLE IF NOT EXISTS projects (
-                id TEXT PRIMARY KEY,
+                uuid TEXT PRIMARY KEY,
+                remote_id TEXT NOT NULL UNIQUE,
                 name TEXT NOT NULL,
                 color TEXT,
                 is_favorite BOOLEAN NOT NULL DEFAULT 0,
                 is_inbox_project BOOLEAN NOT NULL DEFAULT 0,
                 order_index INTEGER NOT NULL DEFAULT 0,
-                parent_id TEXT REFERENCES projects(id) ON DELETE CASCADE
+                parent_uuid TEXT REFERENCES projects(uuid) ON DELETE CASCADE
             )",
         )
         .execute(&self.pool)
@@ -84,9 +85,10 @@ impl LocalStorage {
         sqlx::query(
             r"
             CREATE TABLE IF NOT EXISTS sections (
-                id TEXT PRIMARY KEY,
+                uuid TEXT PRIMARY KEY,
+                remote_id TEXT NOT NULL UNIQUE,
                 name TEXT NOT NULL,
-                project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+                project_uuid TEXT NOT NULL REFERENCES projects(uuid) ON DELETE CASCADE,
                 order_index INTEGER NOT NULL DEFAULT 0
             )",
         )
@@ -97,12 +99,13 @@ impl LocalStorage {
         sqlx::query(
             r"
             CREATE TABLE IF NOT EXISTS tasks (
-                id TEXT PRIMARY KEY,
+                uuid TEXT PRIMARY KEY,
+                remote_id TEXT NOT NULL UNIQUE,
                 content TEXT NOT NULL,
                 description TEXT,
-                project_id TEXT NOT NULL,
-                section_id TEXT,
-                parent_id TEXT,
+                project_uuid TEXT NOT NULL,
+                section_uuid TEXT,
+                parent_uuid TEXT,
                 priority INTEGER NOT NULL DEFAULT 1,
                 order_index INTEGER NOT NULL DEFAULT 0,
                 due_date TEXT,
@@ -112,9 +115,9 @@ impl LocalStorage {
                 duration TEXT,
                 is_completed BOOLEAN NOT NULL DEFAULT 0,
                 is_deleted BOOLEAN NOT NULL DEFAULT 0,
-                FOREIGN KEY (parent_id) REFERENCES tasks(id) ON DELETE CASCADE,
-                FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
-                FOREIGN KEY (section_id) REFERENCES sections(id) ON DELETE SET NULL
+                FOREIGN KEY (parent_uuid) REFERENCES tasks(uuid) ON DELETE CASCADE,
+                FOREIGN KEY (project_uuid) REFERENCES projects(uuid) ON DELETE CASCADE,
+                FOREIGN KEY (section_uuid) REFERENCES sections(uuid) ON DELETE SET NULL
             )",
         )
         .execute(&self.pool)
@@ -124,7 +127,8 @@ impl LocalStorage {
         sqlx::query(
             r"
             CREATE TABLE IF NOT EXISTS labels (
-                id TEXT PRIMARY KEY,
+                uuid TEXT PRIMARY KEY,
+                remote_id TEXT NOT NULL UNIQUE,
                 name TEXT NOT NULL,
                 color TEXT NOT NULL,
                 order_index INTEGER NOT NULL DEFAULT 0,
@@ -138,35 +142,35 @@ impl LocalStorage {
         sqlx::query(
             r"
             CREATE TABLE IF NOT EXISTS task_labels (
-                task_id TEXT NOT NULL,
-                label_id TEXT NOT NULL,
-                PRIMARY KEY (task_id, label_id),
-                FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
-                FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE
+                task_uuid TEXT NOT NULL,
+                label_uuid TEXT NOT NULL,
+                PRIMARY KEY (task_uuid, label_uuid),
+                FOREIGN KEY (task_uuid) REFERENCES tasks(uuid) ON DELETE CASCADE,
+                FOREIGN KEY (label_uuid) REFERENCES labels(uuid) ON DELETE CASCADE
             )",
         )
         .execute(&self.pool)
         .await?;
 
         // Create indexes for performance
-        sqlx::query("CREATE INDEX IF NOT EXISTS idx_task_labels_task_id ON task_labels(task_id)")
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_task_labels_task_uuid ON task_labels(task_uuid)")
             .execute(&self.pool)
             .await?;
 
-        sqlx::query("CREATE INDEX IF NOT EXISTS idx_task_labels_label_id ON task_labels(label_id)")
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_task_labels_label_uuid ON task_labels(label_uuid)")
             .execute(&self.pool)
             .await?;
 
         // Create indexes for tasks table
-        sqlx::query("CREATE INDEX IF NOT EXISTS idx_tasks_project_id ON tasks(project_id)")
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_tasks_project_uuid ON tasks(project_uuid)")
             .execute(&self.pool)
             .await?;
 
-        sqlx::query("CREATE INDEX IF NOT EXISTS idx_tasks_section_id ON tasks(section_id)")
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_tasks_section_uuid ON tasks(section_uuid)")
             .execute(&self.pool)
             .await?;
 
-        sqlx::query("CREATE INDEX IF NOT EXISTS idx_tasks_parent_id ON tasks(parent_id)")
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_tasks_parent_uuid ON tasks(parent_uuid)")
             .execute(&self.pool)
             .await?;
 
@@ -192,5 +196,17 @@ impl LocalStorage {
         tx.commit().await?;
 
         Ok(())
+    }
+
+    /// Generic helper to get local UUID from remote ID for any table
+    pub(crate) async fn find_uuid_by_remote_id(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        table: &str,
+        remote_id: &str,
+    ) -> Result<Option<String>> {
+        let query = format!("SELECT uuid FROM {} WHERE remote_id = ?", table);
+        let uuid = sqlx::query_scalar(&query).bind(remote_id).fetch_optional(&mut **tx).await?;
+        Ok(uuid)
     }
 }

--- a/src/storage/projects.rs
+++ b/src/storage/projects.rs
@@ -7,23 +7,24 @@ use crate::todoist::{Project, ProjectDisplay};
 /// Local project representation with sync metadata
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct LocalProject {
-    pub id: String,
+    pub uuid: String,
+    pub remote_id: String,
     pub name: String,
     pub color: String,
     pub is_favorite: bool,
     pub is_inbox_project: bool,
     pub order_index: i32,
-    pub parent_id: Option<String>,
+    pub parent_uuid: Option<String>,
 }
 
 impl From<LocalProject> for ProjectDisplay {
     fn from(local: LocalProject) -> Self {
         Self {
-            id: local.id,
+            id: local.uuid,
             name: local.name,
             color: local.color,
             is_favorite: local.is_favorite,
-            parent_id: local.parent_id,
+            parent_id: local.parent_uuid,
             is_inbox_project: local.is_inbox_project,
         }
     }
@@ -32,13 +33,14 @@ impl From<LocalProject> for ProjectDisplay {
 impl From<Project> for LocalProject {
     fn from(project: Project) -> Self {
         Self {
-            id: project.id,
+            uuid: uuid::Uuid::new_v4().to_string(),
+            remote_id: project.id,
             name: project.name,
             color: project.color,
             is_favorite: project.is_favorite,
             is_inbox_project: project.is_inbox_project,
             order_index: project.order,
-            parent_id: project.parent_id,
+            parent_uuid: None, // Will be resolved at storage layer
         }
     }
 }
@@ -48,27 +50,48 @@ impl LocalStorage {
     pub async fn store_projects(&self, projects: Vec<Project>) -> Result<()> {
         let mut tx = self.pool.begin().await?;
 
-        // Clear existing projects
-        sqlx::query("DELETE FROM projects").execute(&mut *tx).await?;
-
-        // Insert new projects
+        // First pass: Upsert all projects without parent_uuid relationships
+        // This preserves existing UUIDs when remote_id matches
         for project in &projects {
             let local_project: LocalProject = project.clone().into();
+
             sqlx::query(
                 r"
-                INSERT INTO projects (id, name, color, is_favorite, is_inbox_project, order_index, parent_id)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO projects (uuid, remote_id, name, color, is_favorite, is_inbox_project, order_index, parent_uuid)
+                VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+                ON CONFLICT(remote_id) DO UPDATE SET
+                    name = excluded.name,
+                    color = excluded.color,
+                    is_favorite = excluded.is_favorite,
+                    is_inbox_project = excluded.is_inbox_project,
+                    order_index = excluded.order_index,
+                    parent_uuid = NULL
                 ",
             )
-            .bind(&local_project.id)
+            .bind(&local_project.uuid)
+            .bind(&local_project.remote_id)
             .bind(&local_project.name)
             .bind(&local_project.color)
             .bind(local_project.is_favorite)
             .bind(local_project.is_inbox_project)
             .bind(local_project.order_index)
-            .bind(&local_project.parent_id)
             .execute(&mut *tx)
             .await?;
+        }
+
+        // Second pass: Update parent_uuid references to use local UUIDs
+        for project in &projects {
+            if let Some(remote_parent_id) = &project.parent_id {
+                if let Some(local_parent_uuid) =
+                    self.find_uuid_by_remote_id(&mut tx, "projects", remote_parent_id).await?
+                {
+                    sqlx::query("UPDATE projects SET parent_uuid = ? WHERE remote_id = ?")
+                        .bind(&local_parent_uuid)
+                        .bind(&project.id)
+                        .execute(&mut *tx)
+                        .await?;
+                }
+            }
         }
 
         tx.commit().await?;
@@ -81,17 +104,18 @@ impl LocalStorage {
 
         sqlx::query(
             r"
-            INSERT OR REPLACE INTO projects (id, name, color, is_favorite, is_inbox_project, order_index, parent_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT OR REPLACE INTO projects (uuid, remote_id, name, color, is_favorite, is_inbox_project, order_index, parent_uuid)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ",
         )
-        .bind(&local_project.id)
+        .bind(&local_project.uuid)
+        .bind(&local_project.remote_id)
         .bind(&local_project.name)
         .bind(&local_project.color)
         .bind(local_project.is_favorite)
         .bind(local_project.is_inbox_project)
         .bind(local_project.order_index)
-        .bind(&local_project.parent_id)
+        .bind(&local_project.parent_uuid)
         .execute(&self.pool)
         .await?;
 
@@ -103,12 +127,12 @@ impl LocalStorage {
         let mut tx = self.pool.begin().await?;
 
         // Delete tasks first, then the project
-        sqlx::query("DELETE FROM tasks WHERE project_id = ?")
+        sqlx::query("DELETE FROM tasks WHERE project_uuid = ?")
             .bind(project_id)
             .execute(&mut *tx)
             .await?;
 
-        sqlx::query("DELETE FROM projects WHERE id = ?")
+        sqlx::query("DELETE FROM projects WHERE uuid = ?")
             .bind(project_id)
             .execute(&mut *tx)
             .await?;
@@ -119,7 +143,7 @@ impl LocalStorage {
 
     /// Update project name in local storage
     pub async fn update_project_name(&self, project_id: &str, name: &str) -> Result<()> {
-        sqlx::query("UPDATE projects SET name = ? WHERE id = ?")
+        sqlx::query("UPDATE projects SET name = ? WHERE uuid = ?")
             .bind(name)
             .bind(project_id)
             .execute(&self.pool)
@@ -130,7 +154,7 @@ impl LocalStorage {
     /// Get all projects from local storage
     pub async fn get_projects(&self) -> Result<Vec<ProjectDisplay>> {
         let projects = sqlx::query_as::<_, LocalProject>(
-            "SELECT id, name, color, is_favorite, parent_id, is_inbox_project, order_index FROM projects ORDER BY order_index, name"
+            "SELECT uuid, remote_id, name, color, is_favorite, parent_uuid, is_inbox_project, order_index FROM projects ORDER BY order_index, name"
         )
         .fetch_all(&self.pool)
         .await?

--- a/src/storage/tasks.rs
+++ b/src/storage/tasks.rs
@@ -6,12 +6,13 @@ use crate::todoist::{LabelDisplay, Task, TaskDisplay};
 /// Local task representation with sync metadata
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct LocalTask {
-    pub id: String,
+    pub uuid: String,
+    pub remote_id: String,
     pub content: String,
     pub description: Option<String>,
-    pub project_id: String,
-    pub section_id: Option<String>,
-    pub parent_id: Option<String>,
+    pub project_uuid: String,
+    pub section_uuid: Option<String>,
+    pub parent_uuid: Option<String>,
     pub priority: i32,
     pub order_index: i32,
     pub due_date: Option<String>,
@@ -33,11 +34,12 @@ impl From<Task> for LocalTask {
         });
 
         Self {
-            id: task.id,
+            uuid: uuid::Uuid::new_v4().to_string(),
+            remote_id: task.id,
             content: task.content,
-            project_id: task.project_id,
-            section_id: task.section_id,
-            parent_id: task.parent_id,
+            project_uuid: String::new(), // Will be resolved at storage layer
+            section_uuid: None,          // Will be resolved at storage layer
+            parent_uuid: None,           // Will be resolved at storage layer
             priority: task.priority,
             order_index: task.order,
             due_date: task.due.as_ref().map(|d| d.date.clone()),
@@ -57,10 +59,10 @@ impl LocalStorage {
     async fn get_labels_for_task(&self, task_id: &str) -> Result<Vec<LabelDisplay>> {
         let labels = sqlx::query_as::<_, LocalLabel>(
             r"
-            SELECT l.id, l.name, l.color, l.order_index, l.is_favorite
+            SELECT l.uuid, l.remote_id, l.name, l.color, l.order_index, l.is_favorite
             FROM labels l
-            INNER JOIN task_labels tl ON l.id = tl.label_id
-            WHERE tl.task_id = ?
+            INNER JOIN task_labels tl ON l.uuid = tl.label_uuid
+            WHERE tl.task_uuid = ?
             ORDER BY l.order_index ASC
             ",
         )
@@ -69,7 +71,7 @@ impl LocalStorage {
         .await?
         .into_iter()
         .map(|label| LabelDisplay {
-            id: label.id,
+            id: label.uuid,
             name: label.name,
             color: label.color,
         })
@@ -96,7 +98,7 @@ impl LocalStorage {
         let query = format!(
             r"
             SELECT
-                id, content, project_id, section_id, parent_id, priority, order_index,
+                uuid, remote_id, content, project_uuid, section_uuid, parent_uuid, priority, order_index,
                 due_date, due_datetime, is_recurring, deadline, duration, description,
                 is_completed, is_deleted
             FROM tasks
@@ -115,13 +117,13 @@ impl LocalStorage {
 
         let mut task_displays = Vec::new();
         for task in tasks {
-            let labels = self.get_labels_for_task(&task.id).await?;
+            let labels = self.get_labels_for_task(&task.uuid).await?;
             task_displays.push(TaskDisplay {
-                id: task.id,
+                id: task.remote_id,
                 content: task.content,
-                project_id: task.project_id,
-                section_id: task.section_id,
-                parent_id: task.parent_id,
+                project_id: task.project_uuid,
+                section_id: task.section_uuid,
+                parent_id: task.parent_uuid,
                 priority: task.priority,
                 due: task.due_date,
                 due_datetime: task.due_datetime,
@@ -146,15 +148,15 @@ impl LocalStorage {
         }
 
         #[derive(sqlx::FromRow)]
-        struct LabelIdRow {
-            id: String,
+        struct LabelUuidRow {
+            uuid: String,
         }
 
-        // Get existing label IDs from names
+        // Get existing label UUIDs from names
         let placeholders = label_names.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-        let query = format!("SELECT id FROM labels WHERE name IN ({placeholders})");
+        let query = format!("SELECT uuid FROM labels WHERE name IN ({placeholders})");
 
-        let mut query_builder = sqlx::query_as::<_, LabelIdRow>(&query);
+        let mut query_builder = sqlx::query_as::<_, LabelUuidRow>(&query);
         for name in label_names {
             query_builder = query_builder.bind(name);
         }
@@ -163,9 +165,9 @@ impl LocalStorage {
 
         // Insert task-label relationships for found labels
         for row in label_rows {
-            sqlx::query("INSERT OR IGNORE INTO task_labels (task_id, label_id) VALUES (?, ?)")
+            sqlx::query("INSERT OR IGNORE INTO task_labels (task_uuid, label_uuid) VALUES (?, ?)")
                 .bind(task_id)
-                .bind(&row.id)
+                .bind(&row.uuid)
                 .execute(&self.pool)
                 .await?;
         }
@@ -175,7 +177,7 @@ impl LocalStorage {
 
     /// Remove all label relationships for a task
     async fn clear_task_labels(&self, task_id: &str) -> Result<()> {
-        sqlx::query("DELETE FROM task_labels WHERE task_id = ?")
+        sqlx::query("DELETE FROM task_labels WHERE task_uuid = ?")
             .bind(task_id)
             .execute(&self.pool)
             .await?;
@@ -186,30 +188,53 @@ impl LocalStorage {
     pub async fn store_tasks(&self, tasks: Vec<Task>) -> Result<()> {
         let mut tx = self.pool.begin().await?;
 
-        // Clear existing tasks and their label relationships
-        sqlx::query("DELETE FROM task_labels").execute(&mut *tx).await?;
-        sqlx::query("DELETE FROM tasks").execute(&mut *tx).await?;
-
-        // Collect task info for label processing
+        // First pass: Upsert all tasks without parent_uuid relationships
+        // This preserves existing UUIDs when remote_id matches
         let mut task_labels: Vec<(String, Vec<String>)> = Vec::new();
 
-        // Insert new tasks
-        for task in tasks {
+        for task in &tasks {
             let label_names = task.labels.clone();
-            let local_task: LocalTask = task.into();
-            task_labels.push((local_task.id.clone(), label_names));
+            let mut local_task: LocalTask = task.clone().into();
+
+            // Look up local project UUID from remote project_id
+            if let Some(local_project_uuid) = self.find_uuid_by_remote_id(&mut tx, "projects", &task.project_id).await?
+            {
+                local_task.project_uuid = local_project_uuid;
+            }
+
+            // Look up local section UUID from remote section_id if present
+            if let Some(remote_section_id) = &task.section_id {
+                if let Some(local_section_uuid) =
+                    self.find_uuid_by_remote_id(&mut tx, "sections", remote_section_id).await?
+                {
+                    local_task.section_uuid = Some(local_section_uuid);
+                }
+            }
 
             sqlx::query(
                 r"
-                INSERT INTO tasks (id, content, project_id, section_id, parent_id, priority, order_index, due_date, due_datetime, is_recurring, deadline, duration, description)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO tasks (uuid, remote_id, content, project_uuid, section_uuid, parent_uuid, priority, order_index, due_date, due_datetime, is_recurring, deadline, duration, description)
+                VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(remote_id) DO UPDATE SET
+                    content = excluded.content,
+                    project_uuid = excluded.project_uuid,
+                    section_uuid = excluded.section_uuid,
+                    parent_uuid = NULL,
+                    priority = excluded.priority,
+                    order_index = excluded.order_index,
+                    due_date = excluded.due_date,
+                    due_datetime = excluded.due_datetime,
+                    is_recurring = excluded.is_recurring,
+                    deadline = excluded.deadline,
+                    duration = excluded.duration,
+                    description = excluded.description
                 ",
             )
-            .bind(&local_task.id)
+            .bind(&local_task.uuid)
+            .bind(&local_task.remote_id)
             .bind(&local_task.content)
-            .bind(&local_task.project_id)
-            .bind(&local_task.section_id)
-            .bind(&local_task.parent_id)
+            .bind(&local_task.project_uuid)
+            .bind(&local_task.section_uuid)
             .bind(local_task.priority)
             .bind(local_task.order_index)
             .bind(&local_task.due_date)
@@ -220,13 +245,33 @@ impl LocalStorage {
             .bind(&local_task.description)
             .execute(&mut *tx)
             .await?;
+
+            // Get the uuid of the task we just inserted/updated to use for label relationships
+            if let Some(task_uuid) = self.find_uuid_by_remote_id(&mut tx, "tasks", &task.id).await? {
+                task_labels.push((task_uuid, label_names));
+            }
+        }
+
+        // Second pass: Update parent_uuid references to use local UUIDs
+        for task in &tasks {
+            if let Some(remote_parent_id) = &task.parent_id {
+                if let Some(local_parent_uuid) = self.find_uuid_by_remote_id(&mut tx, "tasks", remote_parent_id).await?
+                {
+                    sqlx::query("UPDATE tasks SET parent_uuid = ? WHERE remote_id = ?")
+                        .bind(&local_parent_uuid)
+                        .bind(&task.id)
+                        .execute(&mut *tx)
+                        .await?;
+                }
+            }
         }
 
         tx.commit().await?;
 
-        // Store label relationships after transaction commits
-        for (task_id, label_names) in task_labels {
-            self.store_task_labels(&task_id, &label_names).await?;
+        // Clear and recreate label relationships
+        sqlx::query("DELETE FROM task_labels").execute(&self.pool).await?;
+        for (task_uuid, label_names) in task_labels {
+            self.store_task_labels(&task_uuid, &label_names).await?;
         }
         Ok(())
     }
@@ -234,22 +279,44 @@ impl LocalStorage {
     /// Store a single task in the database (for immediate insertion after API calls)
     pub async fn store_single_task(&self, task: Task) -> Result<()> {
         let label_names = task.labels.clone();
-        let local_task: LocalTask = task.into();
+        let mut local_task: LocalTask = task.clone().into();
 
         // Use transaction for atomic operation
         let mut tx = self.pool.begin().await?;
 
+        // Look up local project UUID from remote project_id
+        if let Some(local_project_uuid) = self.find_uuid_by_remote_id(&mut tx, "projects", &task.project_id).await? {
+            local_task.project_uuid = local_project_uuid;
+        }
+
+        // Look up local section UUID from remote section_id if present
+        if let Some(remote_section_id) = &task.section_id {
+            if let Some(local_section_uuid) =
+                self.find_uuid_by_remote_id(&mut tx, "sections", remote_section_id).await?
+            {
+                local_task.section_uuid = Some(local_section_uuid);
+            }
+        }
+
+        // Look up local parent UUID from remote parent_id if present
+        if let Some(remote_parent_id) = &task.parent_id {
+            if let Some(local_parent_uuid) = self.find_uuid_by_remote_id(&mut tx, "tasks", remote_parent_id).await? {
+                local_task.parent_uuid = Some(local_parent_uuid);
+            }
+        }
+
         sqlx::query(
             r"
-            INSERT OR REPLACE INTO tasks (id, content, project_id, section_id, parent_id, priority, order_index, due_date, due_datetime, is_recurring, deadline, duration, description, is_completed, is_deleted)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT OR REPLACE INTO tasks (uuid, remote_id, content, project_uuid, section_uuid, parent_uuid, priority, order_index, due_date, due_datetime, is_recurring, deadline, duration, description, is_completed, is_deleted)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ",
         )
-        .bind(&local_task.id)
+        .bind(&local_task.uuid)
+        .bind(&local_task.remote_id)
         .bind(&local_task.content)
-        .bind(&local_task.project_id)
-        .bind(&local_task.section_id)
-        .bind(&local_task.parent_id)
+        .bind(&local_task.project_uuid)
+        .bind(&local_task.section_uuid)
+        .bind(&local_task.parent_uuid)
         .bind(local_task.priority)
         .bind(local_task.order_index)
         .bind(&local_task.due_date)
@@ -266,14 +333,14 @@ impl LocalStorage {
         tx.commit().await?;
 
         // Store label relationships after transaction commits
-        self.clear_task_labels(&local_task.id).await?;
-        self.store_task_labels(&local_task.id, &label_names).await?;
+        self.clear_task_labels(&local_task.uuid).await?;
+        self.store_task_labels(&local_task.uuid, &label_names).await?;
         Ok(())
     }
 
     /// Get tasks for a specific project from local storage
     pub async fn get_tasks_for_project(&self, project_id: &str) -> Result<Vec<TaskDisplay>> {
-        self.get_tasks_with_labels_joined("WHERE project_id = ?", "", &[project_id])
+        self.get_tasks_with_labels_joined("WHERE project_uuid = ?", "", &[project_id])
             .await
     }
 
@@ -340,13 +407,13 @@ impl LocalStorage {
 
     /// Get a single task by ID from local storage
     pub async fn get_task_by_id(&self, task_id: &str) -> Result<Option<TaskDisplay>> {
-        let tasks = self.get_tasks_with_labels_joined("WHERE id = ?", "", &[task_id]).await?;
+        let tasks = self.get_tasks_with_labels_joined("WHERE uuid = ?", "", &[task_id]).await?;
         Ok(tasks.into_iter().next())
     }
 
     /// Mark task as completed (soft completion)
     pub async fn mark_task_completed(&self, task_id: &str) -> Result<()> {
-        sqlx::query("UPDATE tasks SET is_completed = 1 WHERE id = ?")
+        sqlx::query("UPDATE tasks SET is_completed = 1 WHERE uuid = ?")
             .bind(task_id)
             .execute(&self.pool)
             .await?;
@@ -355,7 +422,7 @@ impl LocalStorage {
 
     /// Mark task as deleted (soft deletion)
     pub async fn mark_task_deleted(&self, task_id: &str) -> Result<()> {
-        sqlx::query("UPDATE tasks SET is_deleted = 1 WHERE id = ?")
+        sqlx::query("UPDATE tasks SET is_deleted = 1 WHERE uuid = ?")
             .bind(task_id)
             .execute(&self.pool)
             .await?;
@@ -364,7 +431,7 @@ impl LocalStorage {
 
     /// Restore a soft-deleted task
     pub async fn restore_task(&self, task_id: &str) -> Result<()> {
-        sqlx::query("UPDATE tasks SET is_deleted = 0, is_completed = 0 WHERE id = ?")
+        sqlx::query("UPDATE tasks SET is_deleted = 0, is_completed = 0 WHERE uuid = ?")
             .bind(task_id)
             .execute(&self.pool)
             .await?;
@@ -374,7 +441,7 @@ impl LocalStorage {
     /// Delete a task and its subtasks from local storage (hard delete)
     /// Thanks to CASCADE DELETE, subtasks are automatically removed
     pub async fn delete_task(&self, task_id: &str) -> Result<()> {
-        sqlx::query("DELETE FROM tasks WHERE id = ?")
+        sqlx::query("DELETE FROM tasks WHERE uuid = ?")
             .bind(task_id)
             .execute(&self.pool)
             .await?;
@@ -384,7 +451,7 @@ impl LocalStorage {
 
     /// Update a task's due date in local storage
     pub async fn update_task_due_date(&self, task_id: &str, due_date: Option<&str>) -> Result<()> {
-        sqlx::query("UPDATE tasks SET due_date = ? WHERE id = ?")
+        sqlx::query("UPDATE tasks SET due_date = ? WHERE uuid = ?")
             .bind(due_date)
             .bind(task_id)
             .execute(&self.pool)
@@ -395,7 +462,7 @@ impl LocalStorage {
 
     /// Update a task's priority in local storage
     pub async fn update_task_priority(&self, task_id: &str, priority: i32) -> Result<()> {
-        sqlx::query("UPDATE tasks SET priority = ? WHERE id = ?")
+        sqlx::query("UPDATE tasks SET priority = ? WHERE uuid = ?")
             .bind(priority)
             .bind(task_id)
             .execute(&self.pool)

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -187,7 +187,7 @@ impl SyncService {
         let labels = local_labels
             .into_iter()
             .map(|local| LabelDisplay {
-                id: local.id,
+                id: local.uuid,
                 name: local.name,
                 color: local.color,
             })


### PR DESCRIPTION
this will be needed for the multi-backend coming-soon-ish implementation

