### PR TITLE
Fix accented chars in modals

### DIFF
--- a/src/icons.rs
+++ b/src/icons.rs
@@ -9,20 +9,15 @@
 use serde::{Deserialize, Serialize};
 
 /// Icon theme variants
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum IconTheme {
     /// Emoji icons (colorful, modern look)
     Emoji,
     /// Unicode symbols (clean, native look)
+    #[default]
     Unicode,
     /// ASCII characters (maximum compatibility)
     Ascii,
-}
-
-impl Default for IconTheme {
-    fn default() -> Self {
-        Self::Unicode
-    }
 }
 
 /// Task status icons


### PR DESCRIPTION
## Summary

accented chars were crashing the task creation a project creation modal, it is now fixed

## Changes

- [x] Code changes
- [ ] Tests added/updated
- [ ] Docs updated (README/CHANGELOG)

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes

## Screenshots / Logs (if UI/behavioral change)

## Related issues

Fixes #131



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text input across the app to correctly handle multi-byte characters (emoji, non-ASCII). Cursor movement, insertion, deletion, and navigation now behave reliably in edit dialogs, task creation, and search.

* **Chores**
  * Default icon theme changed to the Unicode icon set, so the app now uses Unicode icons by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->