### PR TITLE
feat: add configurable [theme] section for TUI colors

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -40,7 +40,27 @@ show_project_colors = false       # Show project colors
 
 [logging]
 enabled = false                   # Enable logging to file
+
+[theme]
+accent = "Yellow"                 # Selection highlight color for the sidebar's currently-selected entry
+success = "Green"                 # Completed-task checkmark icon, save/create dialog actions
+danger = "Red"                    # Deleted-task icon/text, delete/cancel shortcuts, error/delete-confirmation dialogs
+warning = "Yellow"                # Sync/loading banner, "Edit Project" dialog accent
+info = "Cyan"                     # Section/account headers, task & label dialog accent, Tab-select hint
+info_dialog = "Blue"              # Border/title accent of the "Info" dialog
+project_accent = "Magenta"        # Border/title accent of the "New Project" dialog
+project_tag = "Cyan"              # Color of the "#project" tag shown next to a task
+due_date = "#FFA500"              # Color of a task's due-date text
+label = "Green"                   # Color of "@label" badges
+text = "White"                    # Default text color for unselected items and dialog content
+text_muted = "DarkGray"           # Descriptions, tree connectors, separators, completed-task text, list scrollbars
+border = "DarkGray"               # Color of the sidebar and task-list borders
+border_dim = "Gray"               # Dialog chrome borders/scrollbars, child-count badge, instruction separators
+selection_bg = "DarkGray"         # Background color of the currently-highlighted row in the task list
 ```
+
+Note: priority-flag colors (P1-P4) are not configurable. They're a fixed part of Terminalist's
+visual language, so they're always red/orange/blue/white regardless of your `[theme]` settings.
 
 ### UI Configuration
 
@@ -66,3 +86,51 @@ enabled = false                   # Enable logging to file
 ### Logging Configuration
 
 - **enabled**: Enable debug logging to file for troubleshooting
+
+### Theme Configuration
+
+Each field accepts either a named color (`"Black"`, `"Red"`, `"Green"`, `"Yellow"`, `"Blue"`, `"Magenta"`,
+`"Cyan"`, `"Gray"`, `"DarkGray"`, `"LightRed"`, `"LightGreen"`, `"LightYellow"`, `"LightBlue"`,
+`"LightMagenta"`, `"LightCyan"`, `"White"`, `"Reset"`) or a hex color (`"#RRGGBB"`). `"Reset"` means "use
+the terminal's own default foreground/background" rather than a fixed color.
+
+Colors are semantic — each field is reused everywhere that meaning applies, so changing one field
+recolors every matching UI element at once:
+
+- **accent**: Selection highlight color for the sidebar's currently-selected entry
+- **success**: Completed-task checkmark icon, and the accent color for save/create actions in dialogs
+- **danger**: Deleted-task icon/text, delete/cancel shortcuts, and the error/delete-confirmation dialogs
+- **warning**: Sync/loading banner, and the "Edit Project" dialog accent
+- **info**: Section/account headers, task & label dialog accent, and the Tab-select hint
+- **info_dialog**: Border/title accent of the "Info" dialog
+- **project_accent**: Border/title accent of the "New Project" dialog
+- **project_tag**: Color of the `#project` tag shown next to a task
+- **due_date**: Color of a task's due-date text
+- **label**: Color of `@label` badges
+- **text**: Default text color for unselected items and dialog content
+- **text_muted**: Descriptions, tree connectors, separators, completed-task text, list scrollbars
+- **border**: Color of the sidebar and task-list borders
+- **border_dim**: Dialog chrome borders/scrollbars, child-count badge, instruction separators
+- **selection_bg**: Background color of the currently-highlighted row in the task list
+
+Priority-flag colors (P1-P4) are intentionally not part of `[theme]` — they're a fixed visual
+language, so they stay hardcoded regardless of your configuration.
+
+Any field omitted from `[theme]` falls back to its built-in default, so you only need to set the
+colors you want to change.
+
+#### Invalid colors
+
+A `[theme]` value that isn't a recognized color (a typo like `"Rde"`, or the wrong type entirely,
+like a number) never crashes the app or fails the rest of your config. Only that one field falls
+back to its default; everything else in `[theme]` (and the rest of the config file) loads
+normally. On startup, Terminalist shows a dialog listing exactly which field(s) fell back and the
+line number in your config file where the problem is, for example:
+
+```
+⚠ 1 theme color in your config could not be applied and fell back to defaults:
+
+• theme.danger (line 12): 'notacolor' is not a valid color, using default
+
+Fix these in your config file, then restart Terminalist.
+```

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@
 //! This module handles loading, parsing, and validation of configuration files.
 
 use crate::constants::{CONFIG_GENERATED, SIDEBAR_DEFAULT_WIDTH, SIDEBAR_MAX_WIDTH, SIDEBAR_MIN_WIDTH};
+use crate::theme::{RawTheme, Theme, ThemeWarning};
 use crate::utils::datetime;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -16,6 +17,19 @@ pub struct Config {
     pub sync: SyncConfig,
     pub display: DisplayConfig,
     pub logging: LoggingConfig,
+    pub theme: Theme,
+}
+
+/// Mirrors [`Config`], but with `theme` left unvalidated so a malformed color value
+/// doesn't fail the whole config load. Used only by [`Config::load_from_file`].
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+struct RawConfig {
+    ui: UiConfig,
+    sync: SyncConfig,
+    display: DisplayConfig,
+    logging: LoggingConfig,
+    theme: RawTheme,
 }
 
 /// UI configuration
@@ -100,27 +114,46 @@ impl Default for DisplayConfig {
 }
 
 impl Config {
-    /// Load configuration from file or return defaults
-    pub fn load() -> Result<Self> {
+    /// Load configuration from file or return defaults.
+    ///
+    /// Returns any [`ThemeWarning`]s produced by falling back to default colors for
+    /// individual `[theme]` values that were missing, malformed, or the wrong type.
+    pub fn load() -> Result<(Self, Vec<ThemeWarning>)> {
         let config_path = Self::find_config_file()?;
 
         if let Some(path) = config_path {
             Self::load_from_file(&path)
         } else {
-            Ok(Self::default())
+            Ok((Self::default(), Vec::new()))
         }
     }
 
-    /// Load configuration from a specific file
-    pub fn load_from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+    /// Load configuration from a specific file.
+    ///
+    /// The `[ui]`, `[sync]`, `[display]`, and `[logging]` sections are parsed strictly, same
+    /// as before — a malformed value there still fails the whole load. The `[theme]` section
+    /// is parsed leniently: any color that's missing, malformed, or the wrong type falls
+    /// back to its built-in default rather than failing the load, and is reported as a
+    /// [`ThemeWarning`] instead.
+    pub fn load_from_file<P: AsRef<Path>>(path: P) -> Result<(Self, Vec<ThemeWarning>)> {
         let content = std::fs::read_to_string(&path)
             .with_context(|| format!("Failed to read config file: {}", path.as_ref().display()))?;
 
-        let config: Config = toml::from_str(&content)
+        let raw: RawConfig = toml::from_str(&content)
             .with_context(|| format!("Failed to parse config file: {}", path.as_ref().display()))?;
 
+        let (theme, warnings) = Theme::from_raw(raw.theme, &content);
+
+        let config = Config {
+            ui: raw.ui,
+            sync: raw.sync,
+            display: raw.display,
+            logging: raw.logging,
+            theme,
+        };
+
         config.validate()?;
-        Ok(config)
+        Ok((config, warnings))
     }
 
     /// Find configuration file in order of precedence

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,9 @@ pub mod storage;
 /// Synchronization engine for keeping local and remote data in sync
 pub mod sync;
 
+/// Theme configuration (semantic color palette) for the TUI
+pub mod theme;
+
 /// Todoist API client and data models
 pub mod todoist;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,10 +85,14 @@ async fn main() -> Result<()> {
     }
 
     // Load configuration
-    let config = config::Config::load()?;
+    let (config, theme_warnings) = config::Config::load()?;
 
     // Initialize logger
     logger::init_logger(config.logging.enabled)?;
+
+    for warning in &theme_warnings {
+        log::warn!("{warning}");
+    }
 
     // Check if API token is set
     if std::env::var("TODOIST_API_TOKEN").is_err() {
@@ -129,7 +133,7 @@ async fn main() -> Result<()> {
     .await
     {
         Ok(Ok(sync_service)) => {
-            ui::run_app(sync_service, config).await?;
+            ui::run_app(sync_service, config, theme_warnings).await?;
         }
         Ok(Err(e)) => {
             return Err(e);

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,374 @@
+//! Theme configuration for the Terminalist TUI.
+//!
+//! Defines the set of semantic colors used throughout the UI. Each field maps to a
+//! meaning (e.g. "danger", "accent") rather than a specific widget, so a single change
+//! propagates everywhere that meaning is used. Colors are stored as `ratatui::style::Color`
+//! and serialized as plain strings (color names like `"blue"` or hex like `"#ff8000"`).
+//!
+//! Priority-flag colors (P1-P4) are intentionally not part of this theme: they're a fixed
+//! visual language, so they stay hardcoded in `ui::components::badge`.
+
+use ratatui::style::Color;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Semantic color palette for the TUI.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Theme {
+    /// Selection highlight color, used for the currently-selected sidebar entry.
+    #[serde(with = "color_serde")]
+    pub accent: Color,
+    /// Completed-task checkmark icon, and the accent color for save/create actions in dialogs.
+    #[serde(with = "color_serde")]
+    pub success: Color,
+    /// Deleted-task icon/text, delete/cancel shortcuts, and the error/delete-confirmation dialogs.
+    #[serde(with = "color_serde")]
+    pub danger: Color,
+    /// Sync/loading banner, and the "Edit Project" dialog accent.
+    #[serde(with = "color_serde")]
+    pub warning: Color,
+    /// Section/account headers, task & label dialog accent, and the Tab-select hint.
+    #[serde(with = "color_serde")]
+    pub info: Color,
+    /// Border/title accent of the "Info" dialog.
+    #[serde(with = "color_serde")]
+    pub info_dialog: Color,
+    /// Border/title accent of the "New Project" dialog.
+    #[serde(with = "color_serde")]
+    pub project_accent: Color,
+    /// Color of the `#project` tag shown next to a task.
+    #[serde(with = "color_serde")]
+    pub project_tag: Color,
+    /// Color of a task's due-date text.
+    #[serde(with = "color_serde")]
+    pub due_date: Color,
+    /// Color of `@label` badges.
+    #[serde(with = "color_serde")]
+    pub label: Color,
+    /// Default text color for unselected items and dialog content.
+    #[serde(with = "color_serde")]
+    pub text: Color,
+    /// Muted text: descriptions, tree connectors, separators, completed-task text, list scrollbars.
+    #[serde(with = "color_serde")]
+    pub text_muted: Color,
+    /// Color of the sidebar and task-list borders.
+    #[serde(with = "color_serde")]
+    pub border: Color,
+    /// Color of dialog chrome borders/scrollbars, the child-count badge, and instruction separators.
+    #[serde(with = "color_serde")]
+    pub border_dim: Color,
+    /// Background color of the currently-highlighted row in the task list.
+    #[serde(with = "color_serde")]
+    pub selection_bg: Color,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self {
+            accent: Color::Yellow,
+            success: Color::Green,
+            danger: Color::Red,
+            warning: Color::Yellow,
+            info: Color::Cyan,
+            info_dialog: Color::Blue,
+            project_accent: Color::Magenta,
+            project_tag: Color::Cyan,
+            due_date: Color::Rgb(255, 165, 0),
+            label: Color::Green,
+            text: Color::White,
+            text_muted: Color::DarkGray,
+            border: Color::DarkGray,
+            border_dim: Color::Gray,
+            selection_bg: Color::DarkGray,
+        }
+    }
+}
+
+/// A single theme field that couldn't be applied as written, so its built-in default was
+/// used instead.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ThemeWarning {
+    /// The `[theme]` key that had a problem (e.g. `"danger"`).
+    pub field: &'static str,
+    /// What was actually written in the config file for that key.
+    pub raw_value: String,
+    /// 1-based line number in the config file where the value appears.
+    pub line: usize,
+}
+
+impl fmt::Display for ThemeWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "theme.{} (line {}): '{}' is not a valid color, using default",
+            self.field, self.line, self.raw_value
+        )
+    }
+}
+
+/// Builds a single user-facing message summarizing a list of [`ThemeWarning`]s, suitable
+/// for showing in an info dialog at startup. Returns `None` if there are no warnings.
+#[must_use]
+pub fn format_warnings(warnings: &[ThemeWarning]) -> Option<String> {
+    if warnings.is_empty() {
+        return None;
+    }
+
+    let noun = if warnings.len() == 1 { "color" } else { "colors" };
+    let mut message = format!(
+        "⚠ {} theme {noun} in your config could not be applied and fell back to defaults:\n",
+        warnings.len()
+    );
+
+    for warning in warnings {
+        message.push_str(&format!("\n• {warning}"));
+    }
+
+    message.push_str("\n\nFix these in your config file, then restart Terminalist.");
+
+    Some(message)
+}
+
+/// Raw (unvalidated) counterpart of [`Theme`] used only for lenient loading from a config
+/// file. Each field is optional (absent = "use the default") and keeps its source span so a
+/// bad value can be reported with a line number, instead of failing the whole config load.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub(crate) struct RawTheme {
+    accent: Option<toml::Spanned<toml::Value>>,
+    success: Option<toml::Spanned<toml::Value>>,
+    danger: Option<toml::Spanned<toml::Value>>,
+    warning: Option<toml::Spanned<toml::Value>>,
+    info: Option<toml::Spanned<toml::Value>>,
+    info_dialog: Option<toml::Spanned<toml::Value>>,
+    project_accent: Option<toml::Spanned<toml::Value>>,
+    project_tag: Option<toml::Spanned<toml::Value>>,
+    due_date: Option<toml::Spanned<toml::Value>>,
+    label: Option<toml::Spanned<toml::Value>>,
+    text: Option<toml::Spanned<toml::Value>>,
+    text_muted: Option<toml::Spanned<toml::Value>>,
+    border: Option<toml::Spanned<toml::Value>>,
+    border_dim: Option<toml::Spanned<toml::Value>>,
+    selection_bg: Option<toml::Spanned<toml::Value>>,
+}
+
+/// 1-based line number containing the given byte offset into `source`.
+fn line_number(source: &str, byte_offset: usize) -> usize {
+    source.get(..byte_offset).unwrap_or(source).matches('\n').count() + 1
+}
+
+impl Theme {
+    /// Builds a [`Theme`] from a [`RawTheme`], falling back to the default for any field
+    /// that is missing, the wrong type, or not a recognized color. Every fallback is
+    /// reported as a [`ThemeWarning`] so the caller can surface it to the user.
+    pub(crate) fn from_raw(raw: RawTheme, source: &str) -> (Theme, Vec<ThemeWarning>) {
+        let defaults = Theme::default();
+        let mut warnings = Vec::new();
+
+        macro_rules! resolve {
+            ($field:ident) => {
+                match raw.$field {
+                    None => defaults.$field,
+                    Some(spanned) => {
+                        let line = line_number(source, spanned.span().start);
+                        match spanned.get_ref().as_str() {
+                            Some(s) => match Color::from_str(s) {
+                                Ok(color) => color,
+                                Err(_) => {
+                                    warnings.push(ThemeWarning {
+                                        field: stringify!($field),
+                                        raw_value: s.to_string(),
+                                        line,
+                                    });
+                                    defaults.$field
+                                }
+                            },
+                            None => {
+                                warnings.push(ThemeWarning {
+                                    field: stringify!($field),
+                                    raw_value: spanned.get_ref().to_string(),
+                                    line,
+                                });
+                                defaults.$field
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        let theme = Theme {
+            accent: resolve!(accent),
+            success: resolve!(success),
+            danger: resolve!(danger),
+            warning: resolve!(warning),
+            info: resolve!(info),
+            info_dialog: resolve!(info_dialog),
+            project_accent: resolve!(project_accent),
+            project_tag: resolve!(project_tag),
+            due_date: resolve!(due_date),
+            label: resolve!(label),
+            text: resolve!(text),
+            text_muted: resolve!(text_muted),
+            border: resolve!(border),
+            border_dim: resolve!(border_dim),
+            selection_bg: resolve!(selection_bg),
+        };
+
+        (theme, warnings)
+    }
+}
+
+/// Serializes/deserializes `ratatui::style::Color` as a plain string, using the color's
+/// own `Display`/`FromStr` impls (which already support names like `"red"` and hex like
+/// `"#ff8000"`).
+mod color_serde {
+    use ratatui::style::Color;
+    use serde::{de::Error as _, Deserialize, Deserializer, Serializer};
+    use std::str::FromStr;
+
+    pub fn serialize<S>(color: &Color, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&color.to_string())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Color, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Color::from_str(&s).map_err(|_| D::Error::custom(format!("invalid color: '{s}'")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_theme_round_trips_through_toml() {
+        let theme = Theme::default();
+        let toml_str = toml::to_string(&theme).expect("serialize theme");
+        let parsed: Theme = toml::from_str(&toml_str).expect("deserialize theme");
+        assert_eq!(theme, parsed);
+    }
+
+    #[test]
+    fn accepts_hex_colors() {
+        let toml_str = r##"due_date = "#ff8000""##;
+        let theme: Theme = toml::from_str(toml_str).expect("deserialize theme");
+        assert_eq!(theme.due_date, Color::Rgb(0xff, 0x80, 0x00));
+    }
+
+    #[test]
+    fn rejects_invalid_colors() {
+        let toml_str = r#"accent = "not-a-color""#;
+        let result: Result<Theme, _> = toml::from_str(toml_str);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_raw_defaults_missing_fields_silently() {
+        let source = "";
+        let raw: RawTheme = toml::from_str(source).unwrap();
+        let (theme, warnings) = Theme::from_raw(raw, source);
+        assert_eq!(theme, Theme::default());
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn from_raw_keeps_valid_overrides_and_defaults_the_rest() {
+        let source = "accent = \"Magenta\"\n";
+        let raw: RawTheme = toml::from_str(source).unwrap();
+        let (theme, warnings) = Theme::from_raw(raw, source);
+        assert_eq!(theme.accent, Color::Magenta);
+        assert_eq!(theme.danger, Theme::default().danger);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn from_raw_falls_back_and_warns_on_invalid_color_string() {
+        let source = "accent = \"Blue\"\ndanger = \"notacolor\"\n";
+        let raw: RawTheme = toml::from_str(source).unwrap();
+        let (theme, warnings) = Theme::from_raw(raw, source);
+
+        assert_eq!(theme.accent, Color::Blue);
+        assert_eq!(
+            theme.danger,
+            Theme::default().danger,
+            "invalid value should fall back to default"
+        );
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].field, "danger");
+        assert_eq!(warnings[0].raw_value, "notacolor");
+        assert_eq!(warnings[0].line, 2);
+    }
+
+    #[test]
+    fn from_raw_falls_back_and_warns_on_wrong_type() {
+        let source = "accent = 5\n";
+        let raw: RawTheme = toml::from_str(source).unwrap();
+        let (theme, warnings) = Theme::from_raw(raw, source);
+
+        assert_eq!(theme.accent, Theme::default().accent);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].field, "accent");
+        assert_eq!(warnings[0].line, 1);
+    }
+
+    #[test]
+    fn from_raw_reports_multiple_warnings_with_correct_lines() {
+        let source = "accent = \"Blue\"\ndanger = \"bogus1\"\nborder = \"bogus2\"\n";
+        let raw: RawTheme = toml::from_str(source).unwrap();
+        let (_, warnings) = Theme::from_raw(raw, source);
+
+        assert_eq!(warnings.len(), 2);
+        assert_eq!(warnings[0].field, "danger");
+        assert_eq!(warnings[0].line, 2);
+        assert_eq!(warnings[1].field, "border");
+        assert_eq!(warnings[1].line, 3);
+    }
+
+    #[test]
+    fn format_warnings_returns_none_when_empty() {
+        assert_eq!(format_warnings(&[]), None);
+    }
+
+    #[test]
+    fn format_warnings_summarizes_all_entries() {
+        let warnings = vec![
+            ThemeWarning {
+                field: "danger",
+                raw_value: "notacolor".to_string(),
+                line: 2,
+            },
+            ThemeWarning {
+                field: "border",
+                raw_value: "bogus".to_string(),
+                line: 3,
+            },
+        ];
+        let message = format_warnings(&warnings).unwrap();
+        assert!(message.contains("2 theme colors"));
+        assert!(message.contains("theme.danger (line 2)"));
+        assert!(message.contains("theme.border (line 3)"));
+    }
+
+    #[test]
+    fn theme_warning_display_is_readable() {
+        let warning = ThemeWarning {
+            field: "danger",
+            raw_value: "notacolor".to_string(),
+            line: 2,
+        };
+        assert_eq!(
+            warning.to_string(),
+            "theme.danger (line 2): 'notacolor' is not a valid color, using default"
+        );
+    }
+}

--- a/src/ui/app_component.rs
+++ b/src/ui/app_component.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::constants::*;
 use crate::entities::{label, project, section, task};
 use crate::sync::{SyncService, SyncStatus};
+use crate::theme::{self, ThemeWarning};
 use crate::ui::components::{DialogComponent, SidebarComponent, TaskListComponent};
 use crate::ui::core::SidebarSelection;
 use crate::ui::core::{
@@ -88,7 +89,7 @@ pub struct AppComponent {
 }
 
 impl AppComponent {
-    pub fn new(sync_service: SyncService, config: Config) -> Self {
+    pub fn new(sync_service: SyncService, config: Config, theme_warnings: Vec<ThemeWarning>) -> Self {
         let sidebar = SidebarComponent::new();
         let task_list = TaskListComponent::new();
         let (task_manager, background_action_rx) = TaskManager::new();
@@ -98,10 +99,15 @@ impl AppComponent {
             ..Default::default()
         };
 
+        let mut dialog = DialogComponent::new();
+        if let Some(message) = theme::format_warnings(&theme_warnings) {
+            dialog.update(Action::ShowDialog(DialogType::Info(message)));
+        }
+
         Self {
             sidebar,
             task_list,
-            dialog: DialogComponent::new(),
+            dialog,
             state,
             sync_service,
             task_manager,
@@ -208,9 +214,11 @@ impl AppComponent {
         // Update sidebar
         self.sidebar.update_data(self.state.projects.clone(), self.state.labels.clone());
         self.sidebar.selection = self.state.sidebar_selection.clone();
+        self.sidebar.update_theme(self.config.theme.clone());
 
         // Update task list
         self.task_list.update_display_config(self.config.display.clone());
+        self.task_list.update_theme(self.config.theme.clone());
         self.task_list.update_data(
             self.state.tasks.clone(),
             self.state.sections.clone(),
@@ -221,6 +229,7 @@ impl AppComponent {
 
         // Update dialog
         self.dialog.update_display_config(self.config.display.clone());
+        self.dialog.update_theme(self.config.theme.clone());
         self.dialog.update_data_with_tasks(
             self.state.projects.clone(),
             self.state.labels.clone(),
@@ -1272,7 +1281,7 @@ impl AppComponent {
     fn render_sync_status_impl(&self, f: &mut Frame, rect: Rect) {
         use ratatui::{
             layout::{Alignment, Constraint, Layout},
-            style::{Color, Style},
+            style::Style,
             text::{Line, Span},
             widgets::{Block, Borders, Clear, Paragraph},
         };
@@ -1296,10 +1305,14 @@ impl AppComponent {
         let spinner = "⟳";
         let content = Paragraph::new(Line::from(Span::styled(
             format!("{} {}…", spinner, title),
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(self.config.theme.warning),
         )))
         .alignment(Alignment::Center)
-        .block(Block::default().borders(Borders::ALL).style(Style::default().fg(Color::Yellow)));
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .style(Style::default().fg(self.config.theme.warning)),
+        );
 
         f.render_widget(Clear, popup_area);
         f.render_widget(content, popup_area);

--- a/src/ui/components/badge.rs
+++ b/src/ui/components/badge.rs
@@ -1,4 +1,5 @@
 use crate::entities::label;
+use crate::theme::Theme;
 use ratatui::{
     style::{Color, Modifier, Style},
     text::Span,
@@ -18,8 +19,8 @@ pub fn create_paren_badge(text: &str) -> Span<'static> {
 
 /// Create a label badge with custom color
 #[must_use]
-pub fn create_label_badge(name: &str) -> Span<'static> {
-    let style = Style::default().fg(Color::Green).add_modifier(Modifier::BOLD);
+pub fn create_label_badge(name: &str, theme: &Theme) -> Span<'static> {
+    let style = Style::default().fg(theme.label).add_modifier(Modifier::BOLD);
 
     Span::styled(format!("@{}", name), style)
 }
@@ -31,6 +32,7 @@ pub fn create_task_badges(
     _has_deadline: bool,
     duration: Option<&str>,
     labels: &[label::Model],
+    theme: &Theme,
 ) -> Vec<Span<'static>> {
     let mut badges = Vec::new();
 
@@ -43,7 +45,7 @@ pub fn create_task_badges(
     }
 
     for label in labels {
-        badges.push(create_label_badge(&label.name));
+        badges.push(create_label_badge(&label.name, theme));
     }
 
     badges

--- a/src/ui/components/dialog_component.rs
+++ b/src/ui/components/dialog_component.rs
@@ -8,6 +8,7 @@ use crate::config::DisplayConfig;
 use crate::entities::{label, project, task};
 use crate::icons::IconService;
 use crate::sync::SyncService;
+use crate::theme::Theme;
 use crate::ui::components::task_list_item_component::{ListItem as TaskListItem, TaskItem};
 use crate::ui::core::{
     actions::{Action, DialogType},
@@ -60,6 +61,7 @@ pub struct DialogComponent {
     pub search_results: Vec<task::Model>,
     pub sync_service: Option<SyncService>,
     pub display_config: DisplayConfig,
+    pub theme: Theme,
 }
 
 impl Default for DialogComponent {
@@ -88,11 +90,16 @@ impl DialogComponent {
             search_results: Vec::new(),
             sync_service: None,
             display_config: DisplayConfig::default(),
+            theme: Theme::default(),
         }
     }
 
     pub fn update_display_config(&mut self, display_config: DisplayConfig) {
         self.display_config = display_config;
+    }
+
+    pub fn update_theme(&mut self, theme: Theme) {
+        self.theme = theme;
     }
 
     pub fn update_data(&mut self, projects: Vec<project::Model>, labels: Vec<label::Model>) {
@@ -319,6 +326,7 @@ impl DialogComponent {
             self.cursor_position,
             &task_projects,
             self.selected_task_project_index,
+            &self.theme,
         );
     }
 
@@ -332,19 +340,41 @@ impl DialogComponent {
             self.cursor_position,
             &root_projects,
             self.selected_parent_project_index,
+            &self.theme,
         );
     }
 
     fn render_project_edit_dialog(&self, f: &mut Frame, area: Rect) {
-        project_dialogs::render_project_edit_dialog(f, area, &self.icons, &self.input_buffer, self.cursor_position);
+        project_dialogs::render_project_edit_dialog(
+            f,
+            area,
+            &self.icons,
+            &self.input_buffer,
+            self.cursor_position,
+            &self.theme,
+        );
     }
 
     fn render_label_creation_dialog(&self, f: &mut Frame, area: Rect) {
-        label_dialogs::render_label_creation_dialog(f, area, &self.icons, &self.input_buffer, self.cursor_position);
+        label_dialogs::render_label_creation_dialog(
+            f,
+            area,
+            &self.icons,
+            &self.input_buffer,
+            self.cursor_position,
+            &self.theme,
+        );
     }
 
     fn render_label_edit_dialog(&self, f: &mut Frame, area: Rect) {
-        label_dialogs::render_label_edit_dialog(f, area, &self.icons, &self.input_buffer, self.cursor_position);
+        label_dialogs::render_label_edit_dialog(
+            f,
+            area,
+            &self.icons,
+            &self.input_buffer,
+            self.cursor_position,
+            &self.theme,
+        );
     }
 
     fn render_task_edit_dialog(&self, f: &mut Frame, area: Rect) {
@@ -365,11 +395,12 @@ impl DialogComponent {
             self.cursor_position,
             &task_projects,
             current_project_index,
+            &self.theme,
         );
     }
 
     fn render_delete_confirmation_dialog(&self, f: &mut Frame, area: Rect, item_type: &str) {
-        system_dialogs::render_delete_confirmation_dialog(f, area, &self.icons, item_type);
+        system_dialogs::render_delete_confirmation_dialog(f, area, &self.icons, item_type, &self.theme);
     }
 
     fn render_info_dialog(&mut self, f: &mut Frame, area: Rect, message: &str) {
@@ -380,6 +411,7 @@ impl DialogComponent {
             message,
             self.scroll_offset,
             &mut self.scrollbar_state,
+            &self.theme,
         );
     }
 
@@ -391,17 +423,18 @@ impl DialogComponent {
             message,
             self.scroll_offset,
             &mut self.scrollbar_state,
+            &self.theme,
         );
     }
 
     fn render_help_dialog(&mut self, f: &mut Frame, area: Rect) {
-        system_dialogs::render_help_dialog(f, area, self.scroll_offset, &mut self.scrollbar_state);
+        system_dialogs::render_help_dialog(f, area, self.scroll_offset, &mut self.scrollbar_state, &self.theme);
     }
 
     fn render_task_search_dialog(&self, f: &mut Frame, area: Rect) {
         use ratatui::{
             layout::{Constraint, Layout, Margin},
-            style::{Color, Style},
+            style::Style,
             widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
         };
 
@@ -434,7 +467,7 @@ impl DialogComponent {
         let main_block = Block::default()
             .title(" Search Tasks ")
             .borders(Borders::ALL)
-            .style(Style::default().fg(Color::Gray));
+            .style(Style::default().fg(self.theme.border_dim));
         f.render_widget(main_block, popup_area);
 
         // Render input field
@@ -442,7 +475,7 @@ impl DialogComponent {
             Block::default()
                 .borders(Borders::ALL)
                 .title("Query")
-                .style(Style::default().fg(Color::Gray)),
+                .style(Style::default().fg(self.theme.border_dim)),
         );
         f.render_widget(input_paragraph, layout[0]);
 
@@ -478,21 +511,21 @@ impl DialogComponent {
                 );
 
                 // Use the same render method as main task list
-                TaskListItem::render(&task_item, false, &self.display_config)
+                TaskListItem::render(&task_item, false, &self.display_config, &self.theme)
             })
             .collect();
 
         let results_block = Block::default()
             .borders(Borders::ALL)
             .title(results_text)
-            .style(Style::default().fg(Color::Gray));
+            .style(Style::default().fg(self.theme.border_dim));
 
         let results_list_widget = List::new(results_list).block(results_block);
         f.render_widget(results_list_widget, layout[1]);
     }
 
     fn render_logs_dialog(&mut self, f: &mut Frame, area: Rect) {
-        system_dialogs::render_logs_dialog(f, area, self.scroll_offset, &mut self.scrollbar_state);
+        system_dialogs::render_logs_dialog(f, area, self.scroll_offset, &mut self.scrollbar_state, &self.theme);
     }
 }
 

--- a/src/ui/components/dialogs/common.rs
+++ b/src/ui/components/dialogs/common.rs
@@ -1,3 +1,4 @@
+use crate::theme::Theme;
 use ratatui::{
     layout::Alignment,
     style::{Color, Modifier, Style},
@@ -16,43 +17,48 @@ pub fn create_dialog_block<'a>(title: &'a str, theme_color: Color) -> Block<'a> 
 }
 
 /// Creates an input field block with a visual cursor
-pub fn create_input_paragraph<'a>(input_buffer: &'a str, _cursor_position: usize, field_title: &str) -> Paragraph<'a> {
+pub fn create_input_paragraph<'a>(
+    input_buffer: &'a str,
+    _cursor_position: usize,
+    field_title: &str,
+    theme: &Theme,
+) -> Paragraph<'a> {
     let input_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .title(format!(" {} ", field_title))
-        .title_style(Style::default().fg(Color::White))
-        .style(Style::default().fg(Color::Gray));
+        .title_style(Style::default().fg(theme.text))
+        .style(Style::default().fg(theme.border_dim));
 
     Paragraph::new(input_buffer)
         .block(input_block)
-        .style(Style::default().fg(Color::White))
+        .style(Style::default().fg(theme.text))
 }
 
 /// Creates a selection field block (read-only display with title)
-pub fn create_selection_paragraph(value: String, field_title: &str) -> Paragraph<'static> {
+pub fn create_selection_paragraph(value: String, field_title: &str, theme: &Theme) -> Paragraph<'static> {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .title(format!(" {} ", field_title))
-        .title_style(Style::default().fg(Color::White))
-        .style(Style::default().fg(Color::Gray));
+        .title_style(Style::default().fg(theme.text))
+        .style(Style::default().fg(theme.border_dim));
 
-    Paragraph::new(value).block(block).style(Style::default().fg(Color::White))
+    Paragraph::new(value).block(block).style(Style::default().fg(theme.text))
 }
 
 /// Instruction shortcut definition: (key, color, description)
 pub type InstructionShortcut = (&'static str, Color, &'static str);
 
 /// Creates a paragraph with color-coded instruction shortcuts
-pub fn create_instructions_paragraph<'a>(instructions: &[InstructionShortcut]) -> Paragraph<'a> {
+pub fn create_instructions_paragraph<'a>(instructions: &[InstructionShortcut], theme: &Theme) -> Paragraph<'a> {
     let mut instruction_text = Vec::new();
     for (key, color, desc) in instructions {
         instruction_text.push(Span::styled(
             *key,
             Style::default().fg(*color).add_modifier(Modifier::BOLD),
         ));
-        instruction_text.push(Span::styled(*desc, Style::default().fg(Color::Gray)));
+        instruction_text.push(Span::styled(*desc, Style::default().fg(theme.border_dim)));
     }
 
     Paragraph::new(Line::from(instruction_text)).alignment(Alignment::Center)
@@ -62,7 +68,15 @@ pub fn create_instructions_paragraph<'a>(instructions: &[InstructionShortcut]) -
 pub mod shortcuts {
     use super::*;
 
-    pub const SEPARATOR: InstructionShortcut = (" • ", Color::Gray, "");
-    pub const ESC_CANCEL: InstructionShortcut = ("Esc", Color::Red, " Cancel");
-    pub const TAB_SELECT: InstructionShortcut = ("Tab", Color::Cyan, " Select");
+    pub fn separator(theme: &Theme) -> InstructionShortcut {
+        (" • ", theme.border_dim, "")
+    }
+
+    pub fn esc_cancel(theme: &Theme) -> InstructionShortcut {
+        ("Esc", theme.danger, " Cancel")
+    }
+
+    pub fn tab_select(theme: &Theme) -> InstructionShortcut {
+        ("Tab", theme.info, " Select")
+    }
 }

--- a/src/ui/components/dialogs/label_dialogs.rs
+++ b/src/ui/components/dialogs/label_dialogs.rs
@@ -1,9 +1,9 @@
 use super::common::{self, shortcuts};
 use crate::icons::IconService;
+use crate::theme::Theme;
 use crate::ui::layout::LayoutManager;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::Color,
     widgets::Clear,
     Frame,
 };
@@ -15,12 +15,13 @@ fn render_label_dialog(
     input_buffer: &str,
     cursor_position: usize,
     is_editing: bool,
+    theme: &Theme,
 ) {
     let dialog_area = LayoutManager::centered_rect_lines(65, 9, area);
     f.render_widget(Clear, dialog_area);
 
     let title = if is_editing { "Edit Label" } else { "New Label" };
-    let main_block = common::create_dialog_block(title, Color::Cyan);
+    let main_block = common::create_dialog_block(title, theme.info);
 
     // Create layout for content
     let inner_area = main_block.inner(dialog_area);
@@ -34,17 +35,17 @@ fn render_label_dialog(
         ])
         .split(inner_area);
 
-    let input_paragraph = common::create_input_paragraph(input_buffer, cursor_position, "Label Name");
+    let input_paragraph = common::create_input_paragraph(input_buffer, cursor_position, "Label Name", theme);
 
     // Instructions based on mode
     let action = if is_editing {
-        ("Enter", Color::Green, " Save Label")
+        ("Enter", theme.success, " Save Label")
     } else {
-        ("Enter", Color::Green, " Create Label")
+        ("Enter", theme.success, " Create Label")
     };
 
-    let instructions = [action, shortcuts::SEPARATOR, shortcuts::ESC_CANCEL];
-    let instructions_paragraph = common::create_instructions_paragraph(&instructions);
+    let instructions = [action, shortcuts::separator(theme), shortcuts::esc_cancel(theme)];
+    let instructions_paragraph = common::create_instructions_paragraph(&instructions, theme);
 
     // Render all components
     f.render_widget(main_block, dialog_area);
@@ -65,8 +66,9 @@ pub fn render_label_creation_dialog(
     icons: &IconService,
     input_buffer: &str,
     cursor_position: usize,
+    theme: &Theme,
 ) {
-    render_label_dialog(f, area, icons, input_buffer, cursor_position, false);
+    render_label_dialog(f, area, icons, input_buffer, cursor_position, false, theme);
 }
 
 pub fn render_label_edit_dialog(
@@ -75,6 +77,7 @@ pub fn render_label_edit_dialog(
     icons: &IconService,
     input_buffer: &str,
     cursor_position: usize,
+    theme: &Theme,
 ) {
-    render_label_dialog(f, area, icons, input_buffer, cursor_position, true);
+    render_label_dialog(f, area, icons, input_buffer, cursor_position, true, theme);
 }

--- a/src/ui/components/dialogs/project_dialogs.rs
+++ b/src/ui/components/dialogs/project_dialogs.rs
@@ -1,13 +1,14 @@
 use super::common::{self, shortcuts};
 use crate::icons::IconService;
+use crate::theme::Theme;
 use crate::ui::layout::LayoutManager;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::Color,
     widgets::Clear,
     Frame,
 };
 
+#[allow(clippy::too_many_arguments)]
 pub fn render_project_creation_dialog(
     f: &mut Frame,
     area: Rect,
@@ -16,11 +17,12 @@ pub fn render_project_creation_dialog(
     cursor_position: usize,
     root_projects: &[&crate::entities::project::Model],
     selected_parent_index: Option<usize>,
+    theme: &Theme,
 ) {
     let dialog_area = LayoutManager::centered_rect_lines(65, 12, area);
     f.render_widget(Clear, dialog_area);
 
-    let main_block = common::create_dialog_block("New Project", Color::Magenta);
+    let main_block = common::create_dialog_block("New Project", theme.project_accent);
 
     // Create layout for content
     let inner_area = main_block.inner(dialog_area);
@@ -35,7 +37,7 @@ pub fn render_project_creation_dialog(
         ])
         .split(inner_area);
 
-    let input_paragraph = common::create_input_paragraph(input_buffer, cursor_position, "Project Name");
+    let input_paragraph = common::create_input_paragraph(input_buffer, cursor_position, "Project Name", theme);
 
     // Parent project selection field
     let parent_project_name = match selected_parent_index {
@@ -49,17 +51,17 @@ pub fn render_project_creation_dialog(
         }
     };
 
-    let parent_paragraph = common::create_selection_paragraph(parent_project_name, "Parent Project");
+    let parent_paragraph = common::create_selection_paragraph(parent_project_name, "Parent Project", theme);
 
     let instructions = [
-        ("Enter", Color::Green, " Create Project"),
-        shortcuts::SEPARATOR,
-        shortcuts::TAB_SELECT,
-        (" Parent", Color::Gray, ""),
-        shortcuts::SEPARATOR,
-        shortcuts::ESC_CANCEL,
+        ("Enter", theme.success, " Create Project"),
+        shortcuts::separator(theme),
+        shortcuts::tab_select(theme),
+        (" Parent", theme.border_dim, ""),
+        shortcuts::separator(theme),
+        shortcuts::esc_cancel(theme),
     ];
-    let instructions_paragraph = common::create_instructions_paragraph(&instructions);
+    let instructions_paragraph = common::create_instructions_paragraph(&instructions, theme);
 
     // Render all components
     f.render_widget(main_block, dialog_area);
@@ -81,11 +83,12 @@ pub fn render_project_edit_dialog(
     _icons: &IconService,
     input_buffer: &str,
     cursor_position: usize,
+    theme: &Theme,
 ) {
     let dialog_area = LayoutManager::centered_rect_lines(65, 9, area);
     f.render_widget(Clear, dialog_area);
 
-    let main_block = common::create_dialog_block("Edit Project", Color::Yellow);
+    let main_block = common::create_dialog_block("Edit Project", theme.warning);
 
     // Create layout for content
     let inner_area = main_block.inner(dialog_area);
@@ -99,14 +102,14 @@ pub fn render_project_edit_dialog(
         ])
         .split(inner_area);
 
-    let input_paragraph = common::create_input_paragraph(input_buffer, cursor_position, "Project Name");
+    let input_paragraph = common::create_input_paragraph(input_buffer, cursor_position, "Project Name", theme);
 
     let instructions = [
-        ("Enter", Color::Green, " Save Changes"),
-        shortcuts::SEPARATOR,
-        shortcuts::ESC_CANCEL,
+        ("Enter", theme.success, " Save Changes"),
+        shortcuts::separator(theme),
+        shortcuts::esc_cancel(theme),
     ];
-    let instructions_paragraph = common::create_instructions_paragraph(&instructions);
+    let instructions_paragraph = common::create_instructions_paragraph(&instructions, theme);
 
     // Render all components
     f.render_widget(main_block, dialog_area);

--- a/src/ui/components/dialogs/system_dialogs.rs
+++ b/src/ui/components/dialogs/system_dialogs.rs
@@ -1,5 +1,6 @@
 use crate::icons::IconService;
 use crate::logger;
+use crate::theme::Theme;
 use crate::ui::layout::LayoutManager;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -24,6 +25,7 @@ fn render_scrollable_message_dialog(
     message: &str,
     scroll_offset: usize,
     scrollbar_state: &mut ScrollbarState,
+    theme: &Theme,
 ) {
     let dialog_area = LayoutManager::centered_rect_lines(config.width_percent, config.height_lines, area);
     f.render_widget(Clear, dialog_area);
@@ -69,12 +71,12 @@ fn render_scrollable_message_dialog(
     };
 
     let message_paragraph = Paragraph::new(message_text)
-        .style(Style::default().fg(Color::White))
+        .style(Style::default().fg(theme.text))
         .alignment(Alignment::Left)
         .wrap(ratatui::widgets::Wrap { trim: true });
 
     let instructions_paragraph = Paragraph::new(instructions)
-        .style(Style::default().fg(Color::Gray))
+        .style(Style::default().fg(theme.border_dim))
         .alignment(Alignment::Center);
 
     f.render_widget(block, dialog_area);
@@ -87,25 +89,31 @@ fn render_scrollable_message_dialog(
             .end_symbol(Some("↓"))
             .track_symbol(Some("│"))
             .thumb_symbol("▐")
-            .style(Style::default().fg(Color::Gray))
-            .thumb_style(Style::default().fg(Color::White));
+            .style(Style::default().fg(theme.border_dim))
+            .thumb_style(Style::default().fg(theme.text));
 
         f.render_stateful_widget(scrollbar, content_area, scrollbar_state);
     }
 }
 
-pub fn render_delete_confirmation_dialog(f: &mut Frame, area: Rect, icons: &IconService, item_type: &str) {
+pub fn render_delete_confirmation_dialog(
+    f: &mut Frame,
+    area: Rect,
+    icons: &IconService,
+    item_type: &str,
+    theme: &Theme,
+) {
     let dialog_area = LayoutManager::centered_rect_lines(60, 8, area);
     f.render_widget(Clear, dialog_area);
 
-    // Main dialog block with rounded borders and red theme (appropriate for deletion)
+    // Main dialog block with rounded borders and danger theme (appropriate for deletion)
     let title = format!("{} Confirm Delete", icons.warning());
     let main_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .title(title)
-        .title_style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
-        .style(Style::default().fg(Color::Red));
+        .title_style(Style::default().fg(theme.danger).add_modifier(Modifier::BOLD))
+        .style(Style::default().fg(theme.danger));
 
     // Create layout for content
     let inner_area = main_block.inner(dialog_area);
@@ -122,14 +130,14 @@ pub fn render_delete_confirmation_dialog(f: &mut Frame, area: Rect, icons: &Icon
     // Confirmation message
     let message = format!("Are you sure you want to delete this {}?", item_type);
     let message_paragraph = Paragraph::new(message)
-        .style(Style::default().fg(Color::White))
+        .style(Style::default().fg(theme.text))
         .alignment(Alignment::Center);
 
     // Enhanced instructions with color-coded shortcuts
     let instructions = vec![
-        ("Enter", Color::Red, " Delete"),
-        (" • ", Color::Gray, ""),
-        ("Esc", Color::Green, " Cancel"),
+        ("Enter", theme.danger, " Delete"),
+        (" • ", theme.border_dim, ""),
+        ("Esc", theme.success, " Cancel"),
     ];
 
     let mut instruction_text = Vec::new();
@@ -138,7 +146,7 @@ pub fn render_delete_confirmation_dialog(f: &mut Frame, area: Rect, icons: &Icon
             key,
             Style::default().fg(color).add_modifier(Modifier::BOLD),
         ));
-        instruction_text.push(ratatui::text::Span::styled(desc, Style::default().fg(Color::Gray)));
+        instruction_text.push(ratatui::text::Span::styled(desc, Style::default().fg(theme.border_dim)));
     }
 
     let instructions_paragraph =
@@ -157,14 +165,15 @@ pub fn render_info_dialog(
     message: &str,
     scroll_offset: usize,
     scrollbar_state: &mut ScrollbarState,
+    theme: &Theme,
 ) {
     let config = ScrollableDialogConfig {
         title: format!("{} Info", icons.info()),
-        color: Color::Blue,
+        color: theme.info_dialog,
         width_percent: 60,
         height_lines: 10,
     };
-    render_scrollable_message_dialog(f, area, config, message, scroll_offset, scrollbar_state);
+    render_scrollable_message_dialog(f, area, config, message, scroll_offset, scrollbar_state, theme);
 }
 
 pub fn render_error_dialog(
@@ -174,17 +183,24 @@ pub fn render_error_dialog(
     message: &str,
     scroll_offset: usize,
     scrollbar_state: &mut ScrollbarState,
+    theme: &Theme,
 ) {
     let config = ScrollableDialogConfig {
         title: format!("{} Error", icons.warning()),
-        color: Color::Red,
+        color: theme.danger,
         width_percent: 70,
         height_lines: 12,
     };
-    render_scrollable_message_dialog(f, area, config, message, scroll_offset, scrollbar_state);
+    render_scrollable_message_dialog(f, area, config, message, scroll_offset, scrollbar_state, theme);
 }
 
-pub fn render_help_dialog(f: &mut Frame, area: Rect, scroll_offset: usize, scrollbar_state: &mut ScrollbarState) {
+pub fn render_help_dialog(
+    f: &mut Frame,
+    area: Rect,
+    scroll_offset: usize,
+    scrollbar_state: &mut ScrollbarState,
+    theme: &Theme,
+) {
     let help_content = r"
 TERMINALIST - Todoist Terminal Client
 ====================================
@@ -290,7 +306,7 @@ Press 'Esc', '?' or 'h' to close this help panel
                 .title("📖 Help - Press 'Esc', '?' or 'h' to close")
                 .title_alignment(Alignment::Center),
         )
-        .style(Style::default().fg(Color::White))
+        .style(Style::default().fg(theme.text))
         .alignment(Alignment::Left);
 
     f.render_widget(help_paragraph, help_content_area);
@@ -301,14 +317,20 @@ Press 'Esc', '?' or 'h' to close this help panel
             .end_symbol(Some("↓"))
             .track_symbol(Some("│"))
             .thumb_symbol("▐")
-            .style(Style::default().fg(Color::Gray))
-            .thumb_style(Style::default().fg(Color::White));
+            .style(Style::default().fg(theme.border_dim))
+            .thumb_style(Style::default().fg(theme.text));
 
         f.render_stateful_widget(scrollbar, help_content_area, scrollbar_state);
     }
 }
 
-pub fn render_logs_dialog(f: &mut Frame, area: Rect, scroll_offset: usize, scrollbar_state: &mut ScrollbarState) {
+pub fn render_logs_dialog(
+    f: &mut Frame,
+    area: Rect,
+    scroll_offset: usize,
+    scrollbar_state: &mut ScrollbarState,
+    theme: &Theme,
+) {
     let logs_area = LayoutManager::centered_rect(90, 90, area);
     f.render_widget(Clear, logs_area);
 
@@ -352,7 +374,7 @@ pub fn render_logs_dialog(f: &mut Frame, area: Rect, scroll_offset: usize, scrol
                 .title("🔍 Debug Logs - Press 'Esc', 'G' or 'q' to close")
                 .title_alignment(Alignment::Center),
         )
-        .style(Style::default().fg(Color::White))
+        .style(Style::default().fg(theme.text))
         .alignment(Alignment::Left);
 
     f.render_widget(logs_paragraph, logs_content_area);
@@ -363,8 +385,8 @@ pub fn render_logs_dialog(f: &mut Frame, area: Rect, scroll_offset: usize, scrol
             .end_symbol(Some("↓"))
             .track_symbol(Some("│"))
             .thumb_symbol("▐")
-            .style(Style::default().fg(Color::Gray))
-            .thumb_style(Style::default().fg(Color::White));
+            .style(Style::default().fg(theme.border_dim))
+            .thumb_style(Style::default().fg(theme.text));
 
         f.render_stateful_widget(scrollbar, logs_content_area, scrollbar_state);
     }

--- a/src/ui/components/dialogs/task_dialogs.rs
+++ b/src/ui/components/dialogs/task_dialogs.rs
@@ -1,10 +1,10 @@
 use super::common::{self, shortcuts};
 use crate::entities::project;
 use crate::icons::IconService;
+use crate::theme::Theme;
 use crate::ui::layout::LayoutManager;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::Color,
     widgets::Clear,
     Frame,
 };
@@ -19,12 +19,13 @@ pub fn render_task_dialog(
     task_projects: &[&project::Model],
     selected_project_index: Option<usize>,
     is_editing: bool,
+    theme: &Theme,
 ) {
     let title = if is_editing { "Edit Task" } else { "New Task" };
     let dialog_area = LayoutManager::centered_rect_lines(65, 12, area);
     f.render_widget(Clear, dialog_area);
 
-    let main_block = common::create_dialog_block(title, Color::Cyan);
+    let main_block = common::create_dialog_block(title, theme.info);
 
     // Create layout for content
     let inner_area = main_block.inner(dialog_area);
@@ -39,7 +40,7 @@ pub fn render_task_dialog(
         ])
         .split(inner_area);
 
-    let input_paragraph = common::create_input_paragraph(input_buffer, cursor_position, "Task Content");
+    let input_paragraph = common::create_input_paragraph(input_buffer, cursor_position, "Task Content", theme);
 
     // Project selection field
     let project_name = match selected_project_index {
@@ -53,24 +54,24 @@ pub fn render_task_dialog(
         }
     };
 
-    let project_paragraph = common::create_selection_paragraph(project_name, "Project");
+    let project_paragraph = common::create_selection_paragraph(project_name, "Project", theme);
 
     // Instructions based on mode
     let action = if is_editing {
-        ("Enter", Color::Green, " Save Task")
+        ("Enter", theme.success, " Save Task")
     } else {
-        ("Enter", Color::Green, " Create Task")
+        ("Enter", theme.success, " Create Task")
     };
 
     let instructions = [
         action,
-        shortcuts::SEPARATOR,
-        shortcuts::TAB_SELECT,
-        (" Project", Color::Gray, ""),
-        shortcuts::SEPARATOR,
-        shortcuts::ESC_CANCEL,
+        shortcuts::separator(theme),
+        shortcuts::tab_select(theme),
+        (" Project", theme.border_dim, ""),
+        shortcuts::separator(theme),
+        shortcuts::esc_cancel(theme),
     ];
-    let instructions_paragraph = common::create_instructions_paragraph(&instructions);
+    let instructions_paragraph = common::create_instructions_paragraph(&instructions, theme);
 
     // Render all components
     f.render_widget(main_block, dialog_area);
@@ -83,6 +84,7 @@ pub fn render_task_dialog(
 }
 
 // Legacy wrapper functions for backward compatibility
+#[allow(clippy::too_many_arguments)]
 pub fn render_task_creation_dialog(
     f: &mut Frame,
     area: Rect,
@@ -91,6 +93,7 @@ pub fn render_task_creation_dialog(
     cursor_position: usize,
     task_projects: &[&project::Model],
     selected_task_project_index: Option<usize>,
+    theme: &Theme,
 ) {
     render_task_dialog(
         f,
@@ -101,9 +104,11 @@ pub fn render_task_creation_dialog(
         task_projects,
         selected_task_project_index,
         false, // is_editing = false for creation
+        theme,
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn render_task_edit_dialog(
     f: &mut Frame,
     area: Rect,
@@ -112,6 +117,7 @@ pub fn render_task_edit_dialog(
     cursor_position: usize,
     task_projects: &[&project::Model],
     selected_task_project_index: Option<usize>,
+    theme: &Theme,
 ) {
     render_task_dialog(
         f,
@@ -122,5 +128,6 @@ pub fn render_task_edit_dialog(
         task_projects,
         selected_task_project_index,
         true, // is_editing = true for editing
+        theme,
     );
 }

--- a/src/ui/components/scrollbar_helper.rs
+++ b/src/ui/components/scrollbar_helper.rs
@@ -102,20 +102,20 @@ impl ScrollbarHelper {
     /// - Vertical orientation on the right side
     /// - Up/down arrow symbols at the ends
     /// - Vertical bar track symbol
-    /// - Dark gray styling for unobtrusive appearance
     ///
     /// # Arguments
     /// * `f` - The frame to render to
     /// * `scrollbar_area` - The area to render the scrollbar in (if Some)
-    pub fn render(&mut self, f: &mut Frame, scrollbar_area: Option<Rect>) {
+    /// * `color` - The color to use for the track and thumb
+    pub fn render(&mut self, f: &mut Frame, scrollbar_area: Option<Rect>, color: Color) {
         if let Some(area) = scrollbar_area {
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
                 .begin_symbol(Some("↑"))
                 .end_symbol(Some("↓"))
                 .track_symbol(Some("│"))
                 .thumb_symbol("█")
-                .style(Style::default().fg(Color::DarkGray))
-                .thumb_style(Style::default().fg(Color::DarkGray));
+                .style(Style::default().fg(color))
+                .thumb_style(Style::default().fg(color));
 
             f.render_stateful_widget(scrollbar, area, &mut self.state);
         }

--- a/src/ui/components/sidebar_component.rs
+++ b/src/ui/components/sidebar_component.rs
@@ -6,6 +6,7 @@
 
 use crate::entities::{label, project};
 use crate::icons::IconService;
+use crate::theme::Theme;
 use crate::ui::components::scrollbar_helper::ScrollbarHelper;
 use crate::ui::components::sidebar_item_component::{SidebarItem, SidebarItemType};
 use crate::ui::core::SidebarSelection;
@@ -13,7 +14,7 @@ use crate::ui::core::{actions::Action, Component};
 use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::{
     layout::Rect,
-    style::{Color, Style},
+    style::Style,
     widgets::{Block, BorderType, Borders, List, ListItem, ListState},
     Frame,
 };
@@ -43,6 +44,7 @@ pub struct SidebarComponent {
     list_state: ListState,
     scroll_position: usize, // Virtual scroll position for view
     scrollbar_helper: ScrollbarHelper,
+    theme: Theme,
 }
 
 impl Default for SidebarComponent {
@@ -65,7 +67,12 @@ impl SidebarComponent {
             list_state,
             scroll_position: 0,
             scrollbar_helper: ScrollbarHelper::new(),
+            theme: Theme::default(),
         }
+    }
+
+    pub fn update_theme(&mut self, theme: Theme) {
+        self.theme = theme;
     }
 
     pub fn update_data(&mut self, projects: Vec<project::Model>, labels: Vec<label::Model>) {
@@ -484,7 +491,7 @@ impl Component for SidebarComponent {
         let all_items: Vec<ListItem> = self
             .items
             .iter()
-            .map(|item| item.render(&self.icons, &self.selection, false))
+            .map(|item| item.render(&self.icons, &self.selection, false, &self.theme))
             .collect();
 
         // Calculate areas for list and scrollbar using helper
@@ -503,14 +510,14 @@ impl Component for SidebarComponent {
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
                     .title("Navigation")
-                    .title_style(Style::default().fg(Color::White))
-                    .border_style(Style::default().fg(Color::DarkGray)),
+                    .title_style(Style::default().fg(self.theme.text))
+                    .border_style(Style::default().fg(self.theme.border)),
             )
-            .style(Style::default().fg(Color::White));
+            .style(Style::default().fg(self.theme.text));
 
         f.render_stateful_widget(list, list_area, &mut self.list_state);
 
         // Render scrollbar using helper
-        self.scrollbar_helper.render(f, scrollbar_area);
+        self.scrollbar_helper.render(f, scrollbar_area, self.theme.text_muted);
     }
 }

--- a/src/ui/components/sidebar_item_component.rs
+++ b/src/ui/components/sidebar_item_component.rs
@@ -5,9 +5,10 @@
 
 use crate::entities::{label, project};
 use crate::icons::IconService;
+use crate::theme::Theme;
 use crate::ui::core::SidebarSelection;
 use ratatui::{
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::ListItem,
 };
@@ -51,6 +52,7 @@ pub trait SidebarItem {
         icons: &'a IconService,
         current_selection: &'a SidebarSelection,
         is_selected: bool,
+        theme: &'a Theme,
     ) -> ListItem<'a>;
 
     /// Whether this item can be selected (navigated to)
@@ -72,14 +74,15 @@ impl SidebarItem for SidebarItemType {
         icons: &'a IconService,
         current_selection: &'a SidebarSelection,
         _is_selected: bool,
+        theme: &'a Theme,
     ) -> ListItem<'a> {
         match self {
             SidebarItemType::SpecialView { name, selection } => {
                 let is_selected = current_selection == selection;
                 let style = if is_selected {
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                    Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(Color::White)
+                    Style::default().fg(theme.text)
                 };
 
                 let icon = match selection {
@@ -96,7 +99,7 @@ impl SidebarItem for SidebarItemType {
             }
 
             SidebarItemType::AccountFolder { name, is_expanded, .. } => {
-                let style = Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+                let style = Style::default().fg(theme.info).add_modifier(Modifier::BOLD);
                 let arrow = if *is_expanded { "▼" } else { "▶" };
                 let icon = "📦";
 
@@ -121,9 +124,9 @@ impl SidebarItem for SidebarItemType {
                     SidebarSelection::Project(idx) if idx == original_index
                 );
                 let style = if is_selected {
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                    Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(Color::White)
+                    Style::default().fg(theme.text)
                 };
 
                 let tree_prefix = if *depth > 0 {
@@ -151,7 +154,7 @@ impl SidebarItem for SidebarItemType {
                 }
 
                 if !tree_prefix.is_empty() {
-                    spans.push(Span::styled(tree_prefix, Style::default().fg(Color::DarkGray)));
+                    spans.push(Span::styled(tree_prefix, Style::default().fg(theme.text_muted)));
                 }
                 spans.push(Span::styled(icon.to_string(), style));
                 spans.push(Span::styled(project.name.clone(), style));
@@ -167,9 +170,9 @@ impl SidebarItem for SidebarItemType {
                     SidebarSelection::Label(idx) if idx == original_index
                 );
                 let style = if is_selected {
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                    Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(Color::White)
+                    Style::default().fg(theme.text)
                 };
 
                 ListItem::new(Line::from(vec![

--- a/src/ui/components/task_list_component.rs
+++ b/src/ui/components/task_list_component.rs
@@ -8,6 +8,7 @@ use crate::config::DisplayConfig;
 use crate::constants::{HEADER_OVERDUE, HEADER_TODAY, HEADER_TOMORROW};
 use crate::entities::{label, project, section, task};
 use crate::icons::IconService;
+use crate::theme::Theme;
 use crate::ui::components::scrollbar_helper::ScrollbarHelper;
 use crate::ui::components::task_list_item_component::{ListItem, TaskItem, TaskListItemType};
 use crate::ui::core::SidebarSelection;
@@ -20,7 +21,7 @@ use chrono::{Duration, Local};
 use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::{
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     widgets::{Block, BorderType, Borders, List, ListItem as RatatuiListItem, ListState},
     Frame,
 };
@@ -50,6 +51,7 @@ pub struct TaskListComponent {
     pub tasks: Vec<task::Model>,
     pub display_config: DisplayConfig,
     scrollbar_helper: ScrollbarHelper,
+    theme: Theme,
 }
 
 impl Default for TaskListComponent {
@@ -72,11 +74,16 @@ impl TaskListComponent {
             icons: IconService::default(),
             display_config: DisplayConfig::default(),
             scrollbar_helper: ScrollbarHelper::new(),
+            theme: Theme::default(),
         }
     }
 
     pub fn update_display_config(&mut self, display_config: DisplayConfig) {
         self.display_config = display_config;
+    }
+
+    pub fn update_theme(&mut self, theme: Theme) {
+        self.theme = theme;
     }
 
     pub fn update_data(
@@ -507,7 +514,7 @@ impl TaskListComponent {
         self.items
             .iter()
             .map(|item| {
-                item.render(false, &self.display_config) // Selection styling handled by List widget
+                item.render(false, &self.display_config, &self.theme) // Selection styling handled by List widget
             })
             .collect()
     }
@@ -636,15 +643,15 @@ impl Component for TaskListComponent {
             List::new(vec![RatatuiListItem::new(empty_message)])
         } else {
             List::new(self.create_list_items(list_area))
-                .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+                .highlight_style(Style::default().bg(self.theme.selection_bg).add_modifier(Modifier::BOLD))
         }
         .block(
             Block::default()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .title("Tasks")
-                .title_style(Style::default().fg(Color::White))
-                .border_style(Style::default().fg(Color::DarkGray)),
+                .title_style(Style::default().fg(self.theme.text))
+                .border_style(Style::default().fg(self.theme.border)),
         );
 
         // Update scrollbar state with current position and viewport info
@@ -656,6 +663,6 @@ impl Component for TaskListComponent {
         f.render_stateful_widget(tasks_list, list_area, &mut self.list_state);
 
         // Render scrollbar using helper
-        self.scrollbar_helper.render(f, scrollbar_area);
+        self.scrollbar_helper.render(f, scrollbar_area, self.theme.text_muted);
     }
 }

--- a/src/ui/components/task_list_item_component.rs
+++ b/src/ui/components/task_list_item_component.rs
@@ -1,10 +1,11 @@
 use crate::config::DisplayConfig;
 use crate::entities::{project, task};
 use crate::icons::IconService;
+use crate::theme::Theme;
 use crate::ui::components::badge::{create_priority_badge, create_task_badges};
 use crate::utils::datetime::{format_human_date, format_human_datetime};
 use ratatui::{
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::ListItem as RatatuiListItem,
 };
@@ -15,7 +16,7 @@ const INDENT_WIDTH: usize = 2;
 /// Trait for items that can be displayed in a task list
 pub trait ListItem {
     /// Render this item as a ratatui ListItem
-    fn render(&self, selected: bool, display_config: &DisplayConfig) -> RatatuiListItem<'static>;
+    fn render(&self, selected: bool, display_config: &DisplayConfig, theme: &Theme) -> RatatuiListItem<'static>;
 
     /// Whether this item can be selected by the user
     fn is_selectable(&self) -> bool;
@@ -33,11 +34,11 @@ pub enum TaskListItemType {
 }
 
 impl ListItem for TaskListItemType {
-    fn render(&self, selected: bool, display_config: &DisplayConfig) -> RatatuiListItem<'static> {
+    fn render(&self, selected: bool, display_config: &DisplayConfig, theme: &Theme) -> RatatuiListItem<'static> {
         match self {
-            Self::Task(item) => item.render(selected, display_config),
-            Self::Header(item) => item.render(selected, display_config),
-            Self::Separator(item) => item.render(selected, display_config),
+            Self::Task(item) => item.render(selected, display_config, theme),
+            Self::Header(item) => item.render(selected, display_config, theme),
+            Self::Separator(item) => item.render(selected, display_config, theme),
         }
     }
 
@@ -100,7 +101,7 @@ impl TaskItem {
 }
 
 impl ListItem for TaskItem {
-    fn render(&self, selected: bool, display_config: &DisplayConfig) -> RatatuiListItem<'static> {
+    fn render(&self, selected: bool, display_config: &DisplayConfig, theme: &Theme) -> RatatuiListItem<'static> {
         // Choose the appropriate icon based on task state
         let status_icon = if self.task.is_deleted {
             self.icons.task_deleted()
@@ -122,22 +123,22 @@ impl ListItem for TaskItem {
             // Add tree connector for the current level
             indent_str.push_str("└─");
 
-            line_spans.push(Span::styled(indent_str, Style::default().fg(Color::DarkGray)));
+            line_spans.push(Span::styled(indent_str, Style::default().fg(theme.text_muted)));
         }
 
         // Status icon with state-based styling
         let status_style = if self.task.is_deleted {
-            // Deleted tasks: red icon
-            Style::default().fg(Color::Red)
+            // Deleted tasks: danger color
+            Style::default().fg(theme.danger)
         } else if self.task.is_completed {
-            // Completed tasks: green icon for the tick mark
-            Style::default().fg(Color::Green)
+            // Completed tasks: success color for the tick mark
+            Style::default().fg(theme.success)
         } else if selected {
-            // Selected active tasks: yellow and bold
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+            // Selected active tasks: accent and bold
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)
         } else {
-            // Normal active tasks: white
-            Style::default().fg(Color::White)
+            // Normal active tasks: default text color
+            Style::default().fg(theme.text)
         };
         line_spans.push(Span::styled(format!("{} ", status_icon), status_style));
 
@@ -149,24 +150,24 @@ impl ListItem for TaskItem {
 
         // Task content with selection styling and deleted/completed styling
         let content_style = if self.task.is_deleted {
-            // Deleted tasks: red with strikethrough
-            Style::default().fg(Color::Red).add_modifier(Modifier::CROSSED_OUT)
+            // Deleted tasks: danger color with strikethrough
+            Style::default().fg(theme.danger).add_modifier(Modifier::CROSSED_OUT)
         } else if self.task.is_completed {
-            // Completed tasks: gray with strikethrough
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::CROSSED_OUT)
+            // Completed tasks: muted with strikethrough
+            Style::default().fg(theme.text_muted).add_modifier(Modifier::CROSSED_OUT)
         } else if selected {
-            // Selected active tasks: yellow and bold
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+            // Selected active tasks: accent and bold
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)
         } else {
-            // Normal active tasks: white
-            Style::default().fg(Color::White)
+            // Normal active tasks: default text color
+            Style::default().fg(theme.text)
         };
         line_spans.push(Span::styled(self.task.content.clone(), content_style));
 
         // Child task count (for tasks with children)
         if self.child_count > 0 {
             let progress_text = format!(" ({})", self.child_count);
-            let progress_style = Style::default().fg(Color::Gray);
+            let progress_style = Style::default().fg(theme.border_dim);
             line_spans.push(Span::styled(progress_text, progress_style));
         }
 
@@ -174,10 +175,10 @@ impl ListItem for TaskItem {
         if let Some(project) = self.projects.iter().find(|p| p.uuid == self.task.project_uuid) {
             line_spans.push(Span::raw(" "));
             let project_style = if display_config.show_project_colors {
-                // Use project color if available, otherwise cyan
-                Style::default().fg(Color::Cyan)
+                // Use project color if available, otherwise the theme's project tag color
+                Style::default().fg(theme.project_tag)
             } else {
-                Style::default().fg(Color::Cyan)
+                Style::default().fg(theme.project_tag)
             };
             line_spans.push(Span::styled(format!("#{}", project.name), project_style));
         }
@@ -193,10 +194,7 @@ impl ListItem for TaskItem {
                 self.format_due_date(due_date)
             };
 
-            line_spans.push(Span::styled(
-                formatted_date,
-                Style::default().fg(Color::Rgb(255, 165, 0)), // Orange color
-            ));
+            line_spans.push(Span::styled(formatted_date, Style::default().fg(theme.due_date)));
         }
 
         // Metadata badges (only if configured to show)
@@ -210,6 +208,7 @@ impl ListItem for TaskItem {
                     None
                 },
                 if display_config.show_labels { &self.labels } else { &[] },
+                theme,
             );
 
             for badge in metadata_badges {
@@ -226,11 +225,11 @@ impl ListItem for TaskItem {
                     // Get first line of description
                     let description_line = desc.lines().next().unwrap_or("");
 
-                    // Add the description with separator and grey styling
+                    // Add the description with separator and muted styling
                     line_spans.push(Span::raw(" - "));
                     line_spans.push(Span::styled(
                         description_line.to_string(),
-                        Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+                        Style::default().fg(theme.text_muted).add_modifier(Modifier::ITALIC),
                     ));
                 }
             }
@@ -262,11 +261,11 @@ impl HeaderItem {
 }
 
 impl ListItem for HeaderItem {
-    fn render(&self, _selected: bool, _display_config: &DisplayConfig) -> RatatuiListItem<'static> {
+    fn render(&self, _selected: bool, _display_config: &DisplayConfig, theme: &Theme) -> RatatuiListItem<'static> {
         let indent_str = " ".repeat(self.indent * INDENT_WIDTH);
         RatatuiListItem::new(Line::from(Span::styled(
             format!("{}{}", indent_str, self.text),
-            Style::default().add_modifier(Modifier::BOLD).fg(Color::Cyan),
+            Style::default().add_modifier(Modifier::BOLD).fg(theme.info),
         )))
     }
 
@@ -292,13 +291,13 @@ impl SeparatorItem {
 }
 
 impl ListItem for SeparatorItem {
-    fn render(&self, _selected: bool, _display_config: &DisplayConfig) -> RatatuiListItem<'static> {
+    fn render(&self, _selected: bool, _display_config: &DisplayConfig, theme: &Theme) -> RatatuiListItem<'static> {
         let indent_str = " ".repeat(self.indent * INDENT_WIDTH);
         let separator = " ";
 
         RatatuiListItem::new(Line::from(Span::styled(
             format!("{}{}", indent_str, separator),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.text_muted),
         )))
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -35,14 +35,14 @@
 //! use tokio::sync::Mutex;
 //!
 //! # async fn example() -> anyhow::Result<()> {
-//! let config = Config::load()?;
+//! let (config, theme_warnings) = Config::load()?;
 //! let storage = Arc::new(Mutex::new(LocalStorage::new(false).await?));
 //! let backend_registry = Arc::new(BackendRegistry::new(storage));
 //! // ... initialize and load backends ...
 //! # let backend_uuid = uuid::Uuid::new_v4();
 //! let sync_service = SyncService::new(backend_registry, backend_uuid, false).await?;
 //!
-//! run_app(sync_service, config).await?;
+//! run_app(sync_service, config, theme_warnings).await?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::sync::SyncService;
+use crate::theme::ThemeWarning;
 use crate::ui::app_component::AppComponent;
 use crate::ui::core::{Component, EventHandler, EventType};
 use crossterm::{
@@ -15,7 +16,11 @@ use std::io;
 use tokio::time::{interval, Duration};
 
 /// Enhanced async event loop with proper background task support
-pub async fn run_app(sync_service: SyncService, config: Config) -> anyhow::Result<()> {
+pub async fn run_app(
+    sync_service: SyncService,
+    config: Config,
+    theme_warnings: Vec<ThemeWarning>,
+) -> anyhow::Result<()> {
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -33,7 +38,7 @@ pub async fn run_app(sync_service: SyncService, config: Config) -> anyhow::Resul
     terminal.show_cursor()?;
 
     // Initialize application components
-    let mut app = AppComponent::new(sync_service, config.clone());
+    let mut app = AppComponent::new(sync_service, config.clone(), theme_warnings);
     let mut event_handler = EventHandler::new();
 
     // Start initial sync automatically

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -109,3 +109,73 @@ fn test_generate_config_creates_directory() {
     // Clean up
     let _ = fs::remove_dir_all(&temp_dir);
 }
+
+#[test]
+fn test_load_from_file_with_missing_theme_section_uses_defaults() {
+    use std::fs;
+    use terminalist::theme::Theme;
+
+    let path = std::env::temp_dir().join("terminalist_test_no_theme.toml");
+    fs::write(&path, "[ui]\nsidebar_width = 35\n").unwrap();
+
+    let (config, warnings) = Config::load_from_file(&path).unwrap();
+
+    assert_eq!(config.ui.sidebar_width, 35);
+    assert_eq!(config.theme, Theme::default());
+    assert!(warnings.is_empty());
+
+    let _ = fs::remove_file(&path);
+}
+
+#[test]
+fn test_load_from_file_with_malformed_color_falls_back_and_warns() {
+    use std::fs;
+    use terminalist::theme::Theme;
+
+    let path = std::env::temp_dir().join("terminalist_test_bad_theme.toml");
+    fs::write(
+        &path,
+        "[theme]\naccent = \"Magenta\"\ndanger = \"notacolor\"\nborder = 5\n",
+    )
+    .unwrap();
+
+    let (config, warnings) = Config::load_from_file(&path).unwrap();
+
+    // Valid override applied, invalid ones fell back to defaults instead of crashing.
+    assert_eq!(config.theme.accent, ratatui::style::Color::Magenta);
+    assert_eq!(config.theme.danger, Theme::default().danger);
+    assert_eq!(config.theme.border, Theme::default().border);
+
+    // Other sections were unaffected.
+    assert_eq!(config.ui.sidebar_width, terminalist::constants::SIDEBAR_DEFAULT_WIDTH);
+
+    assert_eq!(warnings.len(), 2);
+    assert!(warnings.iter().any(|w| w.field == "danger" && w.line == 3));
+    assert!(warnings.iter().any(|w| w.field == "border" && w.line == 4));
+
+    let _ = fs::remove_file(&path);
+}
+
+#[test]
+fn test_load_from_file_with_malformed_ui_section_still_fails() {
+    use std::fs;
+
+    // Unrelated (non-theme) sections must keep their existing strict behavior.
+    let path = std::env::temp_dir().join("terminalist_test_bad_ui.toml");
+    fs::write(&path, "[ui]\nsidebar_width = \"not a number\"\n").unwrap();
+
+    let result = Config::load_from_file(&path);
+    assert!(result.is_err());
+
+    let _ = fs::remove_file(&path);
+}
+
+#[test]
+fn test_generate_default_config_includes_theme_section() {
+    let config = Config::default();
+    let toml_str = toml::to_string_pretty(&config).unwrap();
+
+    assert!(toml_str.contains("[theme]"));
+    assert!(toml_str.contains("accent = \"Yellow\""));
+    assert!(toml_str.contains("danger = \"Red\""));
+}


### PR DESCRIPTION
## Summary

Terminalist's colors were previously hardcoded `ratatui::style::Color` literals scattered across ~13 UI files, with no way to change them short of editing source and recompiling. This PR adds a `[theme]` section to the `.config` file so colors can be customized without touching code, along with resilient handling for missing/invalid color values so a typo in the config can't crash the app. Priority-flag colors (P1-P4) are deliberately left out of the theme and stay hardcoded (see "Deliberately not themeable" below).

## What's included

1. **A semantic color palette (`Theme`)**: 15 named fields (`accent`, `success`, `danger`, `warning`, `info`, `info_dialog`, `project_accent`, `project_tag`, `due_date`, `label`, `text`, `text_muted`, `border`, `border_dim`, `selection_bg`), each reused everywhere that meaning applies in the UI. Changing one field recolors every matching element at once (e.g. `danger` covers deleted-task text, delete/cancel shortcuts, and the error/delete-confirmation dialogs).
2. **Colors as plain TOML strings**: values can be a named color (`"Blue"`, `"DarkGray"`, etc.) or hex (`"#RRGGBB"`), using `ratatui::style::Color`'s own `FromStr`/`Display` impls, so no custom parsing code was needed.
3. **Fallback for missing or invalid colors**: a `[theme]` value that's absent, misspelled, or the wrong type (e.g. a bare number) never crashes the app or fails the rest of the config. Only that one field falls back to its default; everything else loads normally. Unrelated config sections (`[ui]`, `[sync]`, `[display]`, `[logging]`) keep the existing strict behavior, a real mistake there still fails to load, unchanged.
4. **Startup warning dialog**: if any theme values fell back to defaults, Terminalist shows a dismissible info dialog on launch naming each offending field, its raw value, and the *line number in the config file*, e.g.:
   ```
   2 theme colors in your config could not be applied and fell back to defaults:

   • theme.danger (line 12): 'notacolor' is not a valid color, using default
   • theme.border (line 15): '5' is not a valid color, using default

   Fix these in your config file, then restart Terminalist.
   ```
5. **Docs**: `docs/CONFIGURATION.md` gained a `### Theme Configuration` section (all 15 fields, what each affects, accepted value formats), a note that priority-flag colors are fixed, and an `#### Invalid colors` subsection describing the fallback/warning behavior.

## Deliberately not themeable: priority-flag colors

The P1-P4 priority flag colors (`badge::create_priority_badge`) are **not** part of `[theme]` and were left completely untouched. Same hardcoded `Color::Red` / `Color::Rgb(255, 165, 0)` / `Color::Blue` / `Color::White` literals as before this PR, with no `theme: &Theme` parameter added to that function at all. They're a fixed visual language rather than a stylistic choice, so making them configurable felt out of scope for a "make the color scheme configurable" PR.

## Implementation notes

- **`src/theme.rs` (new)**:  the `Theme` struct, its `Default` implementation (reproduces the current version's hardcoded colors exactly, so an empty/missing `[theme]` section changes nothing visually), and a `color_serde` module doing the `Color <-> String` (de)serialization.
- **Fallback loading**: `RawTheme` mirrors `Theme` but with every field as `Option<toml::Spanned<toml::Value>>` (via the `toml` crate's `Spanned` type, which carries the byte range of the value in the original source). `Theme::from_raw()` walks each field: valid → applied; absent → default, silently; invalid or wrong type → default, plus a `ThemeWarning { field, raw_value, line }` (line computed by counting newlines before the span's start offset in the original file text).
- **`src/config.rs`**:  added a `RawConfig` mirroring `Config` but with `theme: RawTheme` instead of `Theme`, so the other sections keep their existing strict `Deserialize` behavior and only `[theme]` gets the lenient treatment. `Config::load()` / `Config::load_from_file()` now return `Result<(Config, Vec<ThemeWarning>)>` instead of `Result<Config>`: the only two callers (`main.rs`, and `load()` calling `load_from_file()` internally) were updated accordingly.
- **Threading `Theme` through the UI**: followed the exact pattern already used for `DisplayConfig`: each stateful component (`SidebarComponent`, `TaskListComponent`, `DialogComponent`) gained a `theme: Theme` field and an `update_theme()` setter, called from `AppComponent::sync_component_data()` alongside the existing `update_display_config()` calls. Free-standing render functions (dialog render functions in `dialogs/*.rs`, `SidebarItemType::render`, `TaskItem::render`, `badge::create_label_badge`/`create_task_badges`, etc.) gained a `theme: &Theme` parameter the same way they already took
- **`ScrollbarHelper::render()`** now takes a `Color` parameter instead of a hardcoded gray, so scrollbars pick up `text_muted` (main lists) or `border_dim` (dialog chrome).
- **Startup dialog wiring**: `AppComponent::new()` takes a new `Vec<ThemeWarning>` param (threaded through `run_app()` from `main.rs`); if non-empty, it immediately queues an `Action::ShowDialog(DialogType::Info(message))`, the same mechanism already used for other one-off notifications (e.g. sync-completed messages), so the warning shows on first paint. This dialog uses the existing `render_info_dialog`, title and icon unchanged (`"{icon} Info"`).

## Testing

- **`src/theme.rs`**: 11 unit tests: default round-trips through TOML, hex colors accepted, invalid colors rejected by the strict `Deserialize` path, `from_raw` behavior (missing fields silent, valid overrides kept, invalid values fall back with correct line numbers, including a multi-warning case verifying each gets its own correct line, wrong-type values, and `ThemeWarning`/`format_warnings` display output).
- **`tests/config.rs`**: 4 new tests using real temp files:
  - missing `[theme]` section → defaults, no warnings
  - a mix of one valid override, one invalid color string, and one wrong-type value → config loads successfully, valid override applied, invalid ones default with the right field names and line numbers, other sections unaffected
  - a malformed *non-theme* value (`sidebar_width` as a string) → still a hard failure, confirming the lenient treatment is scoped to `[theme]` only
  - `generate_default_config` output actually contains a `[theme]` section with the expected default values serialized
- `terminalist --generate-config` output confirmed the `[theme]` section serializes with the expected default values (`accent = "Yellow"`, `danger = "Red"`, etc.).  

## Backward compatibility

- Existing config files without a `[theme]` section keep working unchanged, `Theme` derives `Default`, and `Config`'s container-level `#[serde(default)]` fills it in.
- `terminalist --generate-config` now emits a `[theme]` section with all 15 defaults spelled out (documents the option; a user can just delete keys they don't want to override).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable theme colors across the application interface.
  * Supports named colors, hexadecimal values, and resetting colors to defaults.
  * Invalid theme values now fall back individually while reporting the affected field and configuration line.
  * Updated dialogs, task lists, sidebars, badges, scrollbars, and status indicators to use theme settings.

* **Documentation**
  * Expanded configuration documentation with all supported theme options and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->