### PR TITLE
fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,8 @@ We support Homebrew for installation! For other distributions (Debian/Ubuntu, Fe
 
 ### 1. Get your Todoist API Token
 
-1. Go to [Todoist Integrations Settings](https://todoist.com/prefs/integrations)
-2. Find the "API token" section
-3. Copy your API token
+1. Go to [Todoist Developer Settings](https://app.todoist.com/app/settings/integrations/developer)
+2. Copy your API token
 
 ### 2. Set Environment Variable
 


### PR DESCRIPTION
fix broken link

## Summary
The link to integration settings in the readme was broken.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Todoist API token setup instructions with the correct Developer Settings link.
  * Simplified the process to two clear steps: open the settings page and copy the token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->