### PR TITLE
Fix search input focus and shortcuts

### DIFF
--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -39,7 +39,10 @@ This document lists all available keyboard shortcuts and TUI controls.
 
 - **`/`** Open search dialog
 - **Type** Search across all tasks by content
-- **`Enter`** Close search dialog
+- **`↓`** Move focus from the query to search results
+- **`j/k`** or **`↑/↓`** Navigate focused search results
+- **`t`** Set the focused result's due date to today
+- **`Enter`** No action
 - **`Esc`** Close search dialog
 - **`Backspace/Delete`** Edit search query
 - **`Left/Right`** Move cursor in search box

--- a/src/ui/components/dialog_component.rs
+++ b/src/ui/components/dialog_component.rs
@@ -17,7 +17,9 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{layout::Rect, widgets::ScrollbarState, Frame};
 use uuid::Uuid;
 
-use crate::ui::components::dialogs::{label_dialogs, project_dialogs, scroll_behavior, system_dialogs, task_dialogs};
+use crate::ui::components::dialogs::{
+    common, label_dialogs, project_dialogs, scroll_behavior, system_dialogs, task_dialogs,
+};
 
 /// Modal dialog component that handles various user interactions.
 ///
@@ -58,6 +60,8 @@ pub struct DialogComponent {
     pub scrollbar_state: ScrollbarState,
     // Task search state
     pub search_results: Vec<task::Model>,
+    pub search_selected_index: usize,
+    pub search_results_focused: bool,
     pub sync_service: Option<SyncService>,
     pub display_config: DisplayConfig,
 }
@@ -86,6 +90,8 @@ impl DialogComponent {
             scroll_offset: 0,
             scrollbar_state: ScrollbarState::new(0),
             search_results: Vec::new(),
+            search_selected_index: 0,
+            search_results_focused: false,
             sync_service: None,
             display_config: DisplayConfig::default(),
         }
@@ -136,6 +142,10 @@ impl DialogComponent {
         // Only update if this is for the current query (avoid race conditions)
         if query == self.input_buffer {
             self.search_results = results;
+            self.search_selected_index = self.search_selected_index.min(self.search_results.len().saturating_sub(1));
+            if self.search_results.is_empty() {
+                self.search_results_focused = false;
+            }
         }
     }
 
@@ -418,7 +428,7 @@ impl DialogComponent {
         // Clear the area
         f.render_widget(Clear, popup_area);
 
-        // Split into input area and results area
+        // Split into input, results, and search-specific shortcut areas
         let content_area = popup_area.inner(Margin {
             horizontal: 1,
             vertical: 1,
@@ -427,6 +437,7 @@ impl DialogComponent {
         let layout = Layout::vertical([
             Constraint::Length(3), // Input area
             Constraint::Min(0),    // Results area
+            Constraint::Length(1), // Search shortcuts
         ])
         .split(content_area);
 
@@ -446,8 +457,10 @@ impl DialogComponent {
         );
         f.render_widget(input_paragraph, layout[0]);
 
-        // Set cursor position in input field
-        f.set_cursor_position((layout[0].x + 1 + self.cursor_position as u16, layout[0].y + 1));
+        // Show the terminal cursor only while the query field has focus.
+        if !self.search_results_focused {
+            f.set_cursor_position((layout[0].x + 1 + self.cursor_position as u16, layout[0].y + 1));
+        }
 
         // Render search results
         let results_text = if self.search_results.is_empty() {
@@ -463,7 +476,8 @@ impl DialogComponent {
         let results_list: Vec<ListItem> = self
             .search_results
             .iter()
-            .map(|task| {
+            .enumerate()
+            .map(|(index, task)| {
                 // TODO: Load task-label relationships from database
                 let task_labels = Vec::new();
 
@@ -478,7 +492,11 @@ impl DialogComponent {
                 );
 
                 // Use the same render method as main task list
-                TaskListItem::render(&task_item, false, &self.display_config)
+                TaskListItem::render(
+                    &task_item,
+                    self.search_results_focused && self.search_selected_index == index,
+                    &self.display_config,
+                )
             })
             .collect();
 
@@ -489,6 +507,25 @@ impl DialogComponent {
 
         let results_list_widget = List::new(results_list).block(results_block);
         f.render_widget(results_list_widget, layout[1]);
+
+        let instructions = if self.search_results_focused {
+            [
+                ("j/k or ↑/↓", Color::Cyan, " Navigate"),
+                common::shortcuts::SEPARATOR,
+                ("t", Color::Cyan, " Today"),
+                common::shortcuts::SEPARATOR,
+                ("Esc", Color::Red, " Close"),
+            ]
+        } else {
+            [
+                ("Type", Color::Cyan, " Search"),
+                common::shortcuts::SEPARATOR,
+                ("↓", Color::Cyan, " Results"),
+                common::shortcuts::SEPARATOR,
+                ("Esc", Color::Red, " Close"),
+            ]
+        };
+        f.render_widget(common::create_instructions_paragraph(&instructions), layout[2]);
     }
 
     fn render_logs_dialog(&mut self, f: &mut Frame, area: Rect) {
@@ -602,8 +639,48 @@ impl Component for DialogComponent {
             },
             Some(DialogType::TaskSearch) => match key.code {
                 KeyCode::Esc => Action::HideDialog,
-                KeyCode::Enter => Action::HideDialog,
-                KeyCode::Char(c) => {
+                KeyCode::Enter => Action::None,
+                KeyCode::Down => {
+                    if !self.search_results_focused {
+                        if !self.search_results.is_empty() {
+                            self.search_results_focused = true;
+                            self.search_selected_index =
+                                self.search_selected_index.min(self.search_results.len().saturating_sub(1));
+                        }
+                    } else if self.search_selected_index + 1 < self.search_results.len() {
+                        self.search_selected_index += 1;
+                    }
+                    Action::None
+                }
+                KeyCode::Up => {
+                    if self.search_results_focused {
+                        if self.search_selected_index == 0 {
+                            self.search_results_focused = false;
+                        } else {
+                            self.search_selected_index -= 1;
+                        }
+                    }
+                    Action::None
+                }
+                KeyCode::Char('j') if self.search_results_focused => {
+                    if self.search_selected_index + 1 < self.search_results.len() {
+                        self.search_selected_index += 1;
+                    }
+                    Action::None
+                }
+                KeyCode::Char('k') if self.search_results_focused => {
+                    if self.search_selected_index == 0 {
+                        self.search_results_focused = false;
+                    } else {
+                        self.search_selected_index -= 1;
+                    }
+                    Action::None
+                }
+                KeyCode::Char('t') if self.search_results_focused => self
+                    .search_results
+                    .get(self.search_selected_index)
+                    .map_or(Action::None, |task| Action::SetTaskDueToday(task.uuid)),
+                KeyCode::Char(c) if !self.search_results_focused => {
                     let byte_pos: usize = self
                         .input_buffer
                         .chars()
@@ -614,7 +691,7 @@ impl Component for DialogComponent {
                     self.cursor_position += 1;
                     self.trigger_search()
                 }
-                KeyCode::Backspace => {
+                KeyCode::Backspace if !self.search_results_focused => {
                     if self.cursor_position > 0 {
                         let byte_pos: usize = self
                             .input_buffer
@@ -634,7 +711,7 @@ impl Component for DialogComponent {
                     }
                     Action::None
                 }
-                KeyCode::Delete => {
+                KeyCode::Delete if !self.search_results_focused => {
                     let char_count = self.input_buffer.chars().count();
                     if self.cursor_position < char_count {
                         let byte_pos: usize = self
@@ -648,13 +725,13 @@ impl Component for DialogComponent {
                     }
                     Action::None
                 }
-                KeyCode::Left => {
+                KeyCode::Left if !self.search_results_focused => {
                     if self.cursor_position > 0 {
                         self.cursor_position -= 1;
                     }
                     Action::None
                 }
-                KeyCode::Right => {
+                KeyCode::Right if !self.search_results_focused => {
                     let char_count = self.input_buffer.chars().count();
                     if self.cursor_position < char_count {
                         self.cursor_position += 1;
@@ -835,6 +912,8 @@ impl Component for DialogComponent {
                         self.input_buffer.clear();
                         self.cursor_position = 0;
                         self.search_results.clear();
+                        self.search_selected_index = 0;
+                        self.search_results_focused = false;
                     }
                     _ => {
                         self.input_buffer.clear();

--- a/src/ui/components/dialogs/mod.rs
+++ b/src/ui/components/dialogs/mod.rs
@@ -1,4 +1,4 @@
-mod common;
+pub(crate) mod common;
 
 pub mod label_dialogs;
 pub mod project_dialogs;

--- a/tests/ui/components/dialog_component.rs
+++ b/tests/ui/components/dialog_component.rs
@@ -1,7 +1,94 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use terminalist::entities::task;
 use terminalist::ui::components::DialogComponent;
+use terminalist::ui::core::{Action, Component, DialogType};
+use uuid::Uuid;
+
+fn search_task(content: &str) -> task::Model {
+    task::Model {
+        uuid: Uuid::new_v4(),
+        backend_uuid: Uuid::new_v4(),
+        remote_id: Uuid::new_v4().to_string(),
+        content: content.to_string(),
+        description: None,
+        project_uuid: Uuid::new_v4(),
+        section_uuid: None,
+        parent_uuid: None,
+        priority: 1,
+        order_index: 0,
+        due_date: None,
+        due_datetime: None,
+        is_recurring: false,
+        deadline: None,
+        duration: None,
+        is_completed: false,
+        is_deleted: false,
+    }
+}
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
 
 #[test]
 fn test_dialog_component_creation() {
     // Test that DialogComponent can be created without panicking
     let _dialog = DialogComponent::new();
+}
+
+#[test]
+fn test_search_result_navigation_is_bounded() {
+    let mut dialog = DialogComponent::new();
+    dialog.dialog_type = Some(DialogType::TaskSearch);
+    dialog.search_results = vec![search_task("first"), search_task("second")];
+
+    dialog.handle_key_events(key(KeyCode::Down));
+    assert!(dialog.search_results_focused);
+    assert_eq!(dialog.search_selected_index, 0);
+    dialog.handle_key_events(key(KeyCode::Down));
+    assert_eq!(dialog.search_selected_index, 1);
+    dialog.handle_key_events(key(KeyCode::Down));
+    assert_eq!(dialog.search_selected_index, 1);
+
+    dialog.handle_key_events(key(KeyCode::Up));
+    assert_eq!(dialog.search_selected_index, 0);
+    dialog.handle_key_events(key(KeyCode::Up));
+    assert!(!dialog.search_results_focused);
+    assert_eq!(dialog.search_selected_index, 0);
+}
+
+#[test]
+fn test_all_letters_are_entered_while_search_input_is_focused() {
+    let mut dialog = DialogComponent::new();
+    dialog.dialog_type = Some(DialogType::TaskSearch);
+
+    for character in 'a'..='z' {
+        let action = dialog.handle_key_events(key(KeyCode::Char(character)));
+        assert!(matches!(action, Action::SearchTasks(_)));
+    }
+
+    assert_eq!(dialog.input_buffer, "abcdefghijklmnopqrstuvwxyz");
+    assert_eq!(dialog.cursor_position, 26);
+}
+
+#[test]
+fn test_t_sets_selected_search_result_due_today() {
+    let mut dialog = DialogComponent::new();
+    dialog.dialog_type = Some(DialogType::TaskSearch);
+    dialog.search_results = vec![search_task("first"), search_task("second")];
+    dialog.search_selected_index = 1;
+    dialog.search_results_focused = true;
+    let selected_uuid = dialog.search_results[1].uuid;
+
+    let action = dialog.handle_key_events(key(KeyCode::Char('t')));
+
+    assert!(matches!(action, Action::SetTaskDueToday(uuid) if uuid == selected_uuid));
+}
+
+#[test]
+fn test_enter_has_no_search_action() {
+    let mut dialog = DialogComponent::new();
+    dialog.dialog_type = Some(DialogType::TaskSearch);
+
+    assert!(matches!(dialog.handle_key_events(key(KeyCode::Enter)), Action::None));
 }


### PR DESCRIPTION
## What changed

- keep every letter available for typing while the search query has focus
- move focus into search results with the Down arrow and visibly highlight the selected task
- enable result-only shortcuts after focus moves to the results (`j`/`k`, arrow navigation, and `t` for Today)
- add a context-sensitive shortcut bar at the bottom of the search dialog
- leave Enter without an action
- document the search focus model and add regression coverage

## Why

Search result shortcuts were intercepting letters such as `k`, which prevented users from entering ordinary search terms. Separating query focus from result focus makes typing unambiguous while preserving useful task shortcuts after the user deliberately navigates into the results.

## Validation

- `cargo fmt --check`
- `cargo test dialog_component` (5 passed)
- `git diff --check`
- `cargo test` reaches the pre-existing `tests/storage/db.rs::test_local_storage_creation` failure on clean `main`; no storage code is changed here
