### PR TITLE
fix: improve backend error mapping

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -12,19 +12,22 @@ pub mod todoist;
 /// Common error types for backend operations.
 #[derive(Debug, thiserror::Error)]
 pub enum BackendError {
-    #[error("Authentication failed: {0}")]
+    // Messages from backends are already self-describing (e.g. todoist prefixes
+    // "Authentication error: ..."), so Display passes them through without
+    // re-labeling. The variant carries the category for programmatic handling.
+    #[error("{0}")]
     Auth(String),
 
-    #[error("Resource not found: {0}")]
+    #[error("{0}")]
     NotFound(String),
 
-    #[error("Network error: {0}")]
+    #[error("{0}")]
     Network(String),
 
-    #[error("Invalid data: {0}")]
+    #[error("{0}")]
     InvalidData(String),
 
-    #[error("Backend error: {0}")]
+    #[error("{0}")]
     Other(String),
 }
 

--- a/src/backend/todoist.rs
+++ b/src/backend/todoist.rs
@@ -4,8 +4,25 @@ use super::{
     Backend, BackendError, BackendLabel, BackendProject, BackendSection, BackendTask, CreateLabelArgs,
     CreateProjectArgs, CreateTaskArgs, UpdateLabelArgs, UpdateProjectArgs, UpdateTaskArgs,
 };
-use crate::todoist::TodoistWrapper;
+use crate::todoist::{TodoistError, TodoistWrapper};
 use async_trait::async_trait;
+
+fn map_err(e: TodoistError) -> BackendError {
+    match e {
+        TodoistError::AuthenticationError { .. } | TodoistError::AuthorizationError { .. } => {
+            BackendError::Auth(e.to_string())
+        }
+        TodoistError::NotFound { .. } => BackendError::NotFound(e.to_string()),
+        TodoistError::NetworkError { .. }
+        | TodoistError::RateLimited { .. }
+        | TodoistError::ServerError { .. }
+        | TodoistError::EmptyResponse { .. } => BackendError::Network(e.to_string()),
+        TodoistError::ParseError { .. } | TodoistError::ValidationError { .. } => {
+            BackendError::InvalidData(e.to_string())
+        }
+        TodoistError::Generic { .. } => BackendError::Other(e.to_string()),
+    }
+}
 
 /// Todoist backend implementation.
 pub struct TodoistBackend {
@@ -86,11 +103,7 @@ impl Backend for TodoistBackend {
 
         // Fetch all pages with limit=200
         loop {
-            let response = self
-                .wrapper
-                .get_projects(Some(200), cursor.clone())
-                .await
-                .map_err(|e| BackendError::Network(e.to_string()))?;
+            let response = self.wrapper.get_projects(Some(200), cursor.clone()).await.map_err(map_err)?;
 
             all_projects.extend(response.results.iter().map(Self::project_to_backend));
 
@@ -110,11 +123,7 @@ impl Backend for TodoistBackend {
 
         // Fetch all pages with limit=200
         loop {
-            let response = self
-                .wrapper
-                .get_tasks(Some(200), cursor.clone())
-                .await
-                .map_err(|e| BackendError::Network(e.to_string()))?;
+            let response = self.wrapper.get_tasks(Some(200), cursor.clone()).await.map_err(map_err)?;
 
             all_tasks.extend(response.results.iter().map(Self::task_to_backend));
 
@@ -134,11 +143,7 @@ impl Backend for TodoistBackend {
 
         // Fetch all pages with limit=200
         loop {
-            let response = self
-                .wrapper
-                .get_labels(Some(200), cursor.clone())
-                .await
-                .map_err(|e| BackendError::Network(e.to_string()))?;
+            let response = self.wrapper.get_labels(Some(200), cursor.clone()).await.map_err(map_err)?;
 
             all_labels.extend(response.results.iter().map(Self::label_to_backend));
 
@@ -158,11 +163,7 @@ impl Backend for TodoistBackend {
 
         // Fetch all pages with limit=200
         loop {
-            let response = self
-                .wrapper
-                .get_sections(Some(200), cursor.clone())
-                .await
-                .map_err(|e| BackendError::Network(e.to_string()))?;
+            let response = self.wrapper.get_sections(Some(200), cursor.clone()).await.map_err(map_err)?;
 
             all_sections.extend(response.results.iter().map(Self::section_to_backend));
 
@@ -185,11 +186,7 @@ impl Backend for TodoistBackend {
             view_style: None,
         };
 
-        let project = self
-            .wrapper
-            .create_project(&todoist_args)
-            .await
-            .map_err(|e| BackendError::Network(e.to_string()))?;
+        let project = self.wrapper.create_project(&todoist_args).await.map_err(map_err)?;
         Ok(Self::project_to_backend(&project))
     }
 
@@ -201,19 +198,12 @@ impl Backend for TodoistBackend {
             view_style: None,
         };
 
-        let project = self
-            .wrapper
-            .update_project(remote_id, &todoist_args)
-            .await
-            .map_err(|e| BackendError::Network(e.to_string()))?;
+        let project = self.wrapper.update_project(remote_id, &todoist_args).await.map_err(map_err)?;
         Ok(Self::project_to_backend(&project))
     }
 
     async fn delete_project(&self, remote_id: &str) -> Result<(), BackendError> {
-        self.wrapper
-            .delete_project(remote_id)
-            .await
-            .map_err(|e| BackendError::Network(e.to_string()))
+        self.wrapper.delete_project(remote_id).await.map_err(map_err)
     }
 
     async fn create_task(&self, args: CreateTaskArgs) -> Result<BackendTask, BackendError> {
@@ -239,11 +229,7 @@ impl Backend for TodoistBackend {
             ..Default::default()
         };
 
-        let task = self
-            .wrapper
-            .create_task(&todoist_args)
-            .await
-            .map_err(|e| BackendError::Network(e.to_string()))?;
+        let task = self.wrapper.create_task(&todoist_args).await.map_err(map_err)?;
         Ok(Self::task_to_backend(&task))
     }
 
@@ -267,33 +253,20 @@ impl Backend for TodoistBackend {
             ..Default::default()
         };
 
-        let task = self
-            .wrapper
-            .update_task(remote_id, &todoist_args)
-            .await
-            .map_err(|e| BackendError::Network(e.to_string()))?;
+        let task = self.wrapper.update_task(remote_id, &todoist_args).await.map_err(map_err)?;
         Ok(Self::task_to_backend(&task))
     }
 
     async fn delete_task(&self, remote_id: &str) -> Result<(), BackendError> {
-        self.wrapper
-            .delete_task(remote_id)
-            .await
-            .map_err(|e| BackendError::Network(e.to_string()))
+        self.wrapper.delete_task(remote_id).await.map_err(map_err)
     }
 
     async fn complete_task(&self, remote_id: &str) -> Result<(), BackendError> {
-        self.wrapper
-            .complete_task(remote_id)
-            .await
-            .map_err(|e| BackendError::Network(e.to_string()))
+        self.wrapper.complete_task(remote_id).await.map_err(map_err)
     }
 
     async fn reopen_task(&self, remote_id: &str) -> Result<(), BackendError> {
-        self.wrapper
-            .reopen_task(remote_id)
-            .await
-            .map_err(|e| BackendError::Network(e.to_string()))
+        self.wrapper.reopen_task(remote_id).await.map_err(map_err)
     }
 
     async fn create_label(&self, args: CreateLabelArgs) -> Result<BackendLabel, BackendError> {
@@ -304,11 +277,7 @@ impl Backend for TodoistBackend {
             ..Default::default()
         };
 
-        let label = self
-            .wrapper
-            .create_label(&todoist_args)
-            .await
-            .map_err(|e| BackendError::Network(e.to_string()))?;
+        let label = self.wrapper.create_label(&todoist_args).await.map_err(map_err)?;
         Ok(Self::label_to_backend(&label))
     }
 
@@ -320,18 +289,11 @@ impl Backend for TodoistBackend {
             ..Default::default()
         };
 
-        let label = self
-            .wrapper
-            .update_label(remote_id, &todoist_args)
-            .await
-            .map_err(|e| BackendError::Network(e.to_string()))?;
+        let label = self.wrapper.update_label(remote_id, &todoist_args).await.map_err(map_err)?;
         Ok(Self::label_to_backend(&label))
     }
 
     async fn delete_label(&self, remote_id: &str) -> Result<(), BackendError> {
-        self.wrapper
-            .delete_label(remote_id)
-            .await
-            .map_err(|e| BackendError::Network(e.to_string()))
+        self.wrapper.delete_label(remote_id).await.map_err(map_err)
     }
 }

--- a/src/sync/labels.rs
+++ b/src/sync/labels.rs
@@ -32,12 +32,7 @@ impl SyncService {
             name: name.to_string(),
             is_favorite: None,
         };
-        let api_label = self
-            .get_backend()
-            .await?
-            .create_label(label_args)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        let api_label = self.get_backend().await?.create_label(label_args).await?;
 
         // Store the created label in local database immediately for UI refresh
         info!("Storage: Storing new label locally with ID {}", api_label.remote_id);
@@ -76,12 +71,7 @@ impl SyncService {
             name: Some(name.to_string()),
             is_favorite: None,
         };
-        let _label = self
-            .get_backend()
-            .await?
-            .update_label(&remote_id, label_args)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        let _label = self.get_backend().await?.update_label(&remote_id, label_args).await?;
 
         // Update local storage immediately after successful backend call
         info!(
@@ -105,11 +95,7 @@ impl SyncService {
         let remote_id = self.get_label_remote_id(label_uuid).await?;
 
         // Delete label via backend
-        self.get_backend()
-            .await?
-            .delete_label(&remote_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        self.get_backend().await?.delete_label(&remote_id).await?;
 
         // Note: Local storage deletion will be handled by the next sync
         Ok(())

--- a/src/sync/projects.rs
+++ b/src/sync/projects.rs
@@ -56,12 +56,7 @@ impl SyncService {
             parent_remote_id: remote_parent_id,
             is_favorite: None,
         };
-        let backend_project = self
-            .get_backend()
-            .await?
-            .create_project(project_args)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        let backend_project = self.get_backend().await?.create_project(project_args).await?;
 
         // Store the created project in local database immediately for UI refresh
         let storage = self.storage.lock().await;
@@ -105,12 +100,7 @@ impl SyncService {
             name: Some(name.to_string()),
             is_favorite: None,
         };
-        let _project = self
-            .get_backend()
-            .await?
-            .update_project(&remote_id, project_args)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        let _project = self.get_backend().await?.update_project(&remote_id, project_args).await?;
 
         // Update local storage immediately after successful backend call
         let storage = self.storage.lock().await;
@@ -135,11 +125,7 @@ impl SyncService {
         let remote_id = self.get_project_remote_id(project_uuid).await?;
 
         // Delete project via backend
-        self.get_backend()
-            .await?
-            .delete_project(&remote_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        self.get_backend().await?.delete_project(&remote_id).await?;
 
         // Remove from local storage
         let storage = self.storage.lock().await;

--- a/src/sync/tasks.rs
+++ b/src/sync/tasks.rs
@@ -155,12 +155,7 @@ impl SyncService {
             duration: None,
             labels: Vec::new(),
         };
-        let backend_task = self
-            .get_backend()
-            .await?
-            .create_task(task_args)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        let backend_task = self.get_backend().await?.create_task(task_args).await?;
 
         // Store the created task in local database immediately for UI refresh
         let storage = self.storage.lock().await;
@@ -255,12 +250,7 @@ impl SyncService {
             duration: None,
             labels: None,
         };
-        let _task = self
-            .get_backend()
-            .await?
-            .update_task(&remote_id, task_args)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        let _task = self.get_backend().await?.update_task(&remote_id, task_args).await?;
 
         // Update local storage immediately after successful backend call
         let storage = self.storage.lock().await;
@@ -292,12 +282,7 @@ impl SyncService {
             duration: None,
             labels: None,
         };
-        let _task = self
-            .get_backend()
-            .await?
-            .update_task(&remote_id, task_args)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        let _task = self.get_backend().await?.update_task(&remote_id, task_args).await?;
 
         // Then update local storage
         let storage = self.storage.lock().await;
@@ -329,12 +314,7 @@ impl SyncService {
             duration: None,
             labels: None,
         };
-        let _task = self
-            .get_backend()
-            .await?
-            .update_task(&remote_id, task_args)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        let _task = self.get_backend().await?.update_task(&remote_id, task_args).await?;
 
         // Then update local storage
         let storage = self.storage.lock().await;
@@ -364,11 +344,7 @@ impl SyncService {
         let remote_id = self.get_task_remote_id(task_uuid).await?;
 
         // Complete the task via backend using remote_id (this handles subtasks automatically)
-        self.get_backend()
-            .await?
-            .complete_task(&remote_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        self.get_backend().await?.complete_task(&remote_id).await?;
 
         // Then mark as completed in local storage (soft completion)
         let storage = self.storage.lock().await;
@@ -397,11 +373,7 @@ impl SyncService {
         let remote_id = self.get_task_remote_id(task_uuid).await?;
 
         // Delete the task via backend using remote_id
-        self.get_backend()
-            .await?
-            .delete_task(&remote_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+        self.get_backend().await?.delete_task(&remote_id).await?;
 
         // Then mark as deleted in local storage (soft deletion)
         let storage = self.storage.lock().await;
@@ -455,12 +427,7 @@ impl SyncService {
                 labels: Vec::new(), // Labels will be synced separately
             };
 
-            let new_task = self
-                .get_backend()
-                .await?
-                .create_task(task_args)
-                .await
-                .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+            let new_task = self.get_backend().await?.create_task(task_args).await?;
 
             // Update local storage: remove the old soft-deleted task and add the new one
             let storage = self.storage.lock().await;
@@ -537,11 +504,7 @@ impl SyncService {
             // For completed tasks, just reopen them
             let remote_id = task.remote_id.clone();
             drop(storage); // Release the lock before API call
-            self.get_backend()
-                .await?
-                .reopen_task(&remote_id)
-                .await
-                .map_err(|e| anyhow::anyhow!("Backend error: {}", e))?;
+            self.get_backend().await?.reopen_task(&remote_id).await?;
 
             // Clear local completion flag
             let storage = self.storage.lock().await;


### PR DESCRIPTION
Errors from the Todoist API are now mapped to the correct backend error categories, and duplicate "Backend error:" prefixes in messages were removed.