### PR TITLE
feat: include Git revision in version output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,30 @@ Thanks for taking the time to contribute!
 - Show version: `cargo run -- --version`
 - Debug DB mode: `cargo run -- --debug`
 
+### Install the development version locally
+
+To test the current checkout as the globally available `terminalist` command:
+
+```sh
+cargo install --path . --locked --force
+terminalist --version
+```
+
+The version output includes the Git commit and indicates whether the build contained
+uncommitted changes:
+
+```text
+terminalist 0.5.0 (74f4f78, dirty)
+```
+
+Run `command -v terminalist` if the command does not appear to use the expected installation.
+
+To remove the locally installed binary:
+
+```sh
+cargo uninstall terminalist
+```
+
 ## Reporting issues
 
 Please include:
@@ -45,4 +69,3 @@ Please include:
 ---
 
 By contributing, you agree that your contributions will be licensed under the MIT License.
-

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,50 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn git_output(manifest_dir: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git").arg("-C").arg(manifest_dir).args(args).output().ok()?;
+
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn watch_git_path(manifest_dir: &Path, path: &str) {
+    if let Some(path) = git_output(manifest_dir, &["rev-parse", "--git-path", path]) {
+        let path = PathBuf::from(path);
+        let path = if path.is_absolute() {
+            path
+        } else {
+            manifest_dir.join(path)
+        };
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src");
+
+    let manifest_dir = env::var_os("CARGO_MANIFEST_DIR").map(PathBuf::from);
+    let Some(manifest_dir) = manifest_dir.filter(|path| path.join(".git").exists()) else {
+        return;
+    };
+
+    watch_git_path(&manifest_dir, "HEAD");
+    watch_git_path(&manifest_dir, "index");
+    if let Some(head_ref) = git_output(&manifest_dir, &["symbolic-ref", "-q", "HEAD"]) {
+        watch_git_path(&manifest_dir, &head_ref);
+    }
+
+    if let Some(revision) = git_output(&manifest_dir, &["rev-parse", "--short=7", "HEAD"]) {
+        println!("cargo:rustc-env=TERMINALIST_GIT_REVISION={revision}");
+    }
+
+    if git_output(&manifest_dir, &["status", "--porcelain", "--untracked-files=no"])
+        .is_some_and(|status| !status.is_empty())
+    {
+        println!("cargo:rustc-env=TERMINALIST_GIT_DIRTY=1");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,14 @@ use std::sync::Arc;
 use terminalist::{backend_registry, config, logger, storage, sync, ui};
 use tokio::sync::Mutex;
 
+fn version_string(package_name: &str, package_version: &str, revision: Option<&str>, dirty: bool) -> String {
+    match revision {
+        Some(revision) if dirty => format!("{package_name} {package_version} ({revision}, dirty)"),
+        Some(revision) => format!("{package_name} {package_version} ({revision})"),
+        None => format!("{package_name} {package_version}"),
+    }
+}
+
 /// Main entry point for the Terminalist application.
 ///
 /// This function:
@@ -47,7 +55,15 @@ async fn main() -> Result<()> {
     let generate_config = args.iter().any(|arg| arg == "--generate-config");
 
     if show_version {
-        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        println!(
+            "{}",
+            version_string(
+                env!("CARGO_PKG_NAME"),
+                env!("CARGO_PKG_VERSION"),
+                option_env!("TERMINALIST_GIT_REVISION"),
+                option_env!("TERMINALIST_GIT_DIRTY").is_some(),
+            )
+        );
         return Ok(());
     }
 
@@ -144,4 +160,30 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::version_string;
+
+    #[test]
+    fn version_without_git_metadata_uses_package_version() {
+        assert_eq!(version_string("terminalist", "0.5.0", None, false), "terminalist 0.5.0");
+    }
+
+    #[test]
+    fn version_with_clean_revision_includes_commit() {
+        assert_eq!(
+            version_string("terminalist", "0.5.0", Some("74f4f78"), false),
+            "terminalist 0.5.0 (74f4f78)"
+        );
+    }
+
+    #[test]
+    fn version_with_dirty_revision_marks_the_build() {
+        assert_eq!(
+            version_string("terminalist", "0.5.0", Some("74f4f78"), true),
+            "terminalist 0.5.0 (74f4f78, dirty)"
+        );
+    }
 }


### PR DESCRIPTION
## What changed

- include the short Git revision in `terminalist --version` for builds made from a Git checkout;
- append `dirty` when tracked working-tree changes were present at build time;
- keep the ordinary package-version output when Git metadata is unavailable, such as packaged builds;
- document how contributors can install and identify a local development build.

## Why

Local development builds currently share the package version, which makes it difficult to tell which checkout produced an installed binary. Including the revision makes bug reports and local testing easier without changing release-version semantics.

The build script watches Git's actual `HEAD`, index, and current branch-ref paths, as well as `src` and `build.rs`, so Cargo refreshes the revision and dirty state after commits and working-tree changes. Resolving the paths through Git also supports linked worktrees.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- clean manual check: `terminalist 0.5.0 (5c2312a)`
