### PR TITLE
Preserve the local cache across startup and sync failures

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@
 //!
 //! * `-h, --help` - Show help message
 //! * `-V, --version` - Show version information
-//! * `-d, --debug` - Use file-backed SQLite database for debugging
+//! * `-d, --debug` - Start from cached data without an initial remote sync
 //! * `--generate-config` - Generate a default configuration file
 //!
 //! # Environment Variables
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
         println!("OPTIONS:");
         println!("    -h, --help           Show this help message");
         println!("    -V, --version        Show version information");
-        println!("    -d, --debug          Debug mode: keep database file and skip initial sync");
+        println!("    -d, --debug          Start from cached data and skip initial sync");
         println!("    --generate-config    Generate a default configuration file");
         println!();
         println!("ENVIRONMENT VARIABLES:");
@@ -111,18 +111,32 @@ async fn main() -> Result<()> {
     // Initialize backend registry
     let backend_registry = Arc::new(backend_registry::BackendRegistry::new(local_storage.clone()));
 
-    // Create initial Todoist backend (DB is always fresh at startup)
+    // Reuse the persisted Todoist backend when present. Updating its credentials also
+    // creates the in-memory backend instance needed by the sync service.
     let api_token = std::env::var("TODOIST_API_TOKEN")?;
     let credentials = serde_json::json!({ "api_token": api_token }).to_string();
 
-    let backend_uuid = backend_registry
-        .add_backend(
-            "todoist".to_string(),
-            "My Todoist".to_string(),
-            credentials,
-            "{}".to_string(),
-        )
-        .await?;
+    let existing_todoist = backend_registry
+        .list_backends()
+        .await?
+        .into_iter()
+        .find(|backend| backend.backend_type == "todoist");
+
+    let backend_uuid = if let Some(backend) = existing_todoist {
+        backend_registry
+            .update_backend(&backend.uuid, None, Some(credentials), None)
+            .await?;
+        backend.uuid
+    } else {
+        backend_registry
+            .add_backend(
+                "todoist".to_string(),
+                "My Todoist".to_string(),
+                credentials,
+                "{}".to_string(),
+            )
+            .await?
+    };
 
     // Create sync service with timeout
     let timeout = tokio::time::Duration::from_secs(10);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -23,16 +23,22 @@ impl LocalStorage {
         Ok(app_data_dir.join("terminalist.db"))
     }
 
-    /// Initialize the local storage with SQLite database
-    pub async fn new(debug_mode: bool) -> Result<Self> {
+    /// Initialize the local storage with the application SQLite database.
+    ///
+    /// The database is retained between runs and refreshed by the sync layer. Deleting it
+    /// here would invalidate connections held by another running Terminalist process.
+    pub async fn new(_debug_mode: bool) -> Result<Self> {
         let db_path = Self::get_db_path()?;
+        Self::new_at(db_path).await
+    }
 
-        // Normal mode: the DB is a throwaway cache, wiped and rebuilt by initial sync each boot.
-        // Debug mode: keep an existing file so manually-loaded data (e.g. demo_data.sql) survives
-        // and is shown without syncing.
-        let existing = db_path.exists();
-        if !debug_mode && existing {
-            std::fs::remove_file(&db_path)?;
+    /// Open local storage at an explicit path.
+    ///
+    /// This is public so integration tests and alternate frontends can use an isolated
+    /// database without touching the user's application data.
+    pub async fn new_at(db_path: PathBuf) -> Result<Self> {
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).context("Failed to create database directory")?;
         }
 
         let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
@@ -54,10 +60,7 @@ impl LocalStorage {
         .await?;
 
         let storage = LocalStorage { conn };
-        // A kept debug file already has its schema; only build it for a fresh file.
-        if !(debug_mode && existing) {
-            storage.init_schema().await?;
-        }
+        storage.init_schema().await?;
 
         Ok(storage)
     }
@@ -77,7 +80,8 @@ impl LocalStorage {
             schema.create_table_from_entity(task_label::Entity),
         ];
 
-        for statement in table_statements {
+        for mut statement in table_statements {
+            statement.if_not_exists();
             self.conn.execute(backend.build(&statement)).await?;
         }
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -95,6 +95,17 @@ pub enum SyncStatus {
 }
 
 impl SyncService {
+    #[cfg(test)]
+    pub(crate) fn new_for_test(storage: Arc<Mutex<LocalStorage>>, backend_uuid: Uuid) -> Self {
+        Self {
+            backend_registry: Arc::new(crate::backend_registry::BackendRegistry::new(storage.clone())),
+            backend_uuid,
+            storage,
+            sync_in_progress: Arc::new(Mutex::new(false)),
+            debug_mode: false,
+        }
+    }
+
     /// Creates a new `SyncService` instance with the provided backend registry.
     ///
     /// This creates a sync service that manages synchronization for a specific backend.
@@ -256,44 +267,13 @@ impl SyncService {
             let storage = self.storage.lock().await;
             info!("💾 Storing data in local database...");
 
-            // Store projects
-            if let Err(e) = self.store_projects_batch(&storage, &projects).await {
-                error!("❌ Failed to store projects: {e}");
+            if let Err(e) = self.store_snapshot(&storage, &projects, &labels, &sections, &tasks).await {
+                error!("❌ Failed to refresh local cache: {e:#}");
                 return Ok(SyncStatus::Error {
-                    message: format!("Failed to store projects: {e}"),
+                    message: format!("Failed to refresh local cache: {e:#}"),
                 });
             }
-            info!("✅ Stored projects in database");
-
-            // Store labels BEFORE tasks so task-label relationships can be created
-            if let Err(e) = self.store_labels_batch(&storage, &labels).await {
-                error!("❌ Failed to store labels: {e}");
-                return Ok(SyncStatus::Error {
-                    message: format!("Failed to store labels: {e}"),
-                });
-            }
-            info!("✅ Stored labels in database");
-
-            // Store sections BEFORE tasks since tasks have foreign key references to sections
-            if !sections.is_empty() {
-                if let Err(e) = self.store_sections_batch(&storage, &sections).await {
-                    error!("❌ Failed to store sections: {e}");
-                    return Ok(SyncStatus::Error {
-                        message: format!("Failed to store sections: {e}"),
-                    });
-                }
-                info!("✅ Stored sections in database");
-            } else {
-                info!("⚠️  No sections to store (skipped due to backend issue)");
-            }
-
-            if let Err(e) = self.store_tasks_batch(&storage, &tasks).await {
-                error!("❌ Failed to store tasks: {e}");
-                return Ok(SyncStatus::Error {
-                    message: format!("Failed to store tasks: {e}"),
-                });
-            }
-            info!("✅ Stored tasks in database");
+            info!("✅ Refreshed local cache transactionally");
         }
 
         Ok(SyncStatus::Success)

--- a/src/sync/storage.rs
+++ b/src/sync/storage.rs
@@ -2,11 +2,84 @@ use crate::entities::{label, project, section, task, task_label};
 use crate::repositories::{LabelRepository, ProjectRepository, SectionRepository, TaskRepository};
 use crate::storage::LocalStorage;
 use crate::sync::SyncService;
-use anyhow::Result;
-use sea_orm::{ActiveValue, ColumnTrait, EntityTrait, QueryFilter, TransactionTrait};
+use anyhow::{Context, Result};
+use sea_orm::{ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, TransactionTrait};
 use uuid::Uuid;
 
 impl SyncService {
+    /// Atomically replace the locally cached values represented by a remote snapshot.
+    ///
+    /// Fetching happens before this method is called. If any write fails, the transaction
+    /// rolls back and the last valid cache remains available to the UI.
+    pub(super) async fn store_snapshot(
+        &self,
+        storage: &LocalStorage,
+        projects: &[crate::backend::BackendProject],
+        labels: &[crate::backend::BackendLabel],
+        sections: &[crate::backend::BackendSection],
+        tasks: &[crate::backend::BackendTask],
+    ) -> Result<()> {
+        let transaction = storage
+            .conn
+            .begin()
+            .await
+            .context("Failed to start cache refresh transaction")?;
+
+        // A full remote snapshot is authoritative. Clear only this backend's cached
+        // objects inside the same transaction so removed remote objects do not linger,
+        // while any later write failure still restores the previous cache on rollback.
+        task::Entity::delete_many()
+            .filter(task::Column::BackendUuid.eq(self.backend_uuid))
+            .exec(&transaction)
+            .await
+            .context("Failed to clear cached tasks")?;
+        section::Entity::delete_many()
+            .filter(section::Column::BackendUuid.eq(self.backend_uuid))
+            .exec(&transaction)
+            .await
+            .context("Failed to clear cached sections")?;
+        project::Entity::update_many()
+            .col_expr(
+                project::Column::ParentUuid,
+                sea_orm::sea_query::Expr::value(Option::<Uuid>::None),
+            )
+            .filter(project::Column::BackendUuid.eq(self.backend_uuid))
+            .exec(&transaction)
+            .await
+            .context("Failed to detach cached project hierarchy")?;
+        project::Entity::delete_many()
+            .filter(project::Column::BackendUuid.eq(self.backend_uuid))
+            .exec(&transaction)
+            .await
+            .context("Failed to clear cached projects")?;
+        label::Entity::delete_many()
+            .filter(label::Column::BackendUuid.eq(self.backend_uuid))
+            .exec(&transaction)
+            .await
+            .context("Failed to clear cached labels")?;
+
+        self.store_projects_batch(&transaction, projects)
+            .await
+            .context("Failed to store projects")?;
+        self.store_labels_batch(&transaction, labels)
+            .await
+            .context("Failed to store labels")?;
+        if !sections.is_empty() {
+            self.store_sections_batch(&transaction, sections)
+                .await
+                .context("Failed to store sections")?;
+        }
+        self.store_tasks_batch(&transaction, tasks)
+            .await
+            .context("Failed to store tasks")?;
+
+        transaction
+            .commit()
+            .await
+            .context("Failed to commit cache refresh transaction")?;
+        Ok(())
+    }
+
     /// Look up local project UUID from remote project_id.
     ///
     /// # Arguments
@@ -19,13 +92,16 @@ impl SyncService {
     ///
     /// # Errors
     /// Returns error if project with given remote_id doesn't exist locally
-    pub(super) async fn lookup_project_uuid(
-        txn: &sea_orm::DatabaseTransaction,
+    pub(super) async fn lookup_project_uuid<C>(
+        conn: &C,
         backend_uuid: &Uuid,
         remote_project_id: &str,
         context: &str,
-    ) -> Result<Uuid> {
-        if let Some(project) = ProjectRepository::get_by_remote_id(txn, backend_uuid, remote_project_id).await? {
+    ) -> Result<Uuid>
+    where
+        C: ConnectionTrait,
+    {
+        if let Some(project) = ProjectRepository::get_by_remote_id(conn, backend_uuid, remote_project_id).await? {
             Ok(project.uuid)
         } else {
             Err(anyhow::anyhow!(
@@ -47,13 +123,16 @@ impl SyncService {
     ///
     /// # Errors
     /// Returns error if database query fails
-    pub(super) async fn lookup_section_uuid(
-        txn: &sea_orm::DatabaseTransaction,
+    pub(super) async fn lookup_section_uuid<C>(
+        conn: &C,
         backend_uuid: &Uuid,
         remote_section_id: Option<&String>,
-    ) -> Result<Option<Uuid>> {
+    ) -> Result<Option<Uuid>>
+    where
+        C: ConnectionTrait,
+    {
         if let Some(remote_id) = remote_section_id {
-            let section_uuid = SectionRepository::get_by_remote_id(txn, backend_uuid, remote_id)
+            let section_uuid = SectionRepository::get_by_remote_id(conn, backend_uuid, remote_id)
                 .await?
                 .map(|s| s.uuid);
             Ok(section_uuid)
@@ -63,14 +142,15 @@ impl SyncService {
     }
 
     /// Store projects in batch
-    pub(super) async fn store_projects_batch(
+    pub(super) async fn store_projects_batch<C>(
         &self,
-        storage: &LocalStorage,
+        conn: &C,
         projects: &[crate::backend::BackendProject],
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
         use sea_orm::sea_query::OnConflict;
-
-        let txn = storage.conn.begin().await?;
 
         // First pass: Upsert all projects without parent_uuid relationships
         for backend_project in projects {
@@ -97,40 +177,36 @@ impl SyncService {
                     ])
                     .to_owned(),
             );
-            insert.exec(&txn).await?;
+            insert.exec(conn).await?;
         }
 
         // Second pass: Update parent_uuid references to use local UUIDs
         for backend_project in projects {
             if let Some(remote_parent_id) = &backend_project.parent_remote_id {
                 if let Some(parent) =
-                    ProjectRepository::get_by_remote_id(&txn, &self.backend_uuid, remote_parent_id).await?
+                    ProjectRepository::get_by_remote_id(conn, &self.backend_uuid, remote_parent_id).await?
                 {
                     if let Some(project) =
-                        ProjectRepository::get_by_remote_id(&txn, &self.backend_uuid, &backend_project.remote_id)
+                        ProjectRepository::get_by_remote_id(conn, &self.backend_uuid, &backend_project.remote_id)
                             .await?
                     {
                         let mut active_model: project::ActiveModel = project.into();
                         active_model.parent_uuid = ActiveValue::Set(Some(parent.uuid));
-                        ProjectRepository::update(&txn, active_model).await?;
+                        ProjectRepository::update(conn, active_model).await?;
                     }
                 }
             }
         }
 
-        txn.commit().await?;
         Ok(())
     }
 
     /// Store labels in batch
-    pub(super) async fn store_labels_batch(
-        &self,
-        storage: &LocalStorage,
-        labels: &[crate::backend::BackendLabel],
-    ) -> Result<()> {
+    pub(super) async fn store_labels_batch<C>(&self, conn: &C, labels: &[crate::backend::BackendLabel]) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
         use sea_orm::sea_query::OnConflict;
-
-        let txn = storage.conn.begin().await?;
 
         for backend_label in labels {
             let local_label = label::ActiveModel {
@@ -148,22 +224,18 @@ impl SyncService {
                     .update_columns([label::Column::Name, label::Column::OrderIndex, label::Column::IsFavorite])
                     .to_owned(),
             );
-            insert.exec(&txn).await?;
+            insert.exec(conn).await?;
         }
 
-        txn.commit().await?;
         Ok(())
     }
 
     /// Store tasks in batch
-    pub(super) async fn store_tasks_batch(
-        &self,
-        storage: &LocalStorage,
-        tasks: &[crate::backend::BackendTask],
-    ) -> Result<()> {
+    pub(super) async fn store_tasks_batch<C>(&self, conn: &C, tasks: &[crate::backend::BackendTask]) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
         use sea_orm::sea_query::OnConflict;
-
-        let txn = storage.conn.begin().await?;
 
         // Track task labels for later processing
         let mut task_labels_map: Vec<(Uuid, Vec<String>)> = Vec::new();
@@ -174,7 +246,7 @@ impl SyncService {
 
             // Look up local project UUID from remote project_id
             let project_uuid = match Self::lookup_project_uuid(
-                &txn,
+                conn,
                 &self.backend_uuid,
                 &backend_task.project_remote_id,
                 "task batch sync",
@@ -190,7 +262,7 @@ impl SyncService {
 
             // Look up local section UUID from remote section_id if present
             let section_uuid =
-                Self::lookup_section_uuid(&txn, &self.backend_uuid, backend_task.section_remote_id.as_ref()).await?;
+                Self::lookup_section_uuid(conn, &self.backend_uuid, backend_task.section_remote_id.as_ref()).await?;
 
             let local_task = task::ActiveModel {
                 uuid: ActiveValue::Set(Uuid::new_v4()),
@@ -233,11 +305,11 @@ impl SyncService {
                     ])
                     .to_owned(),
             );
-            insert.exec(&txn).await?;
+            insert.exec(conn).await?;
 
             // Get the uuid of the task we just inserted/updated
             if let Some(task) =
-                TaskRepository::get_by_remote_id(&txn, &self.backend_uuid, &backend_task.remote_id).await?
+                TaskRepository::get_by_remote_id(conn, &self.backend_uuid, &backend_task.remote_id).await?
             {
                 task_labels_map.push((task.uuid, label_names));
             }
@@ -247,14 +319,14 @@ impl SyncService {
         for backend_task in tasks {
             if let Some(remote_parent_id) = &backend_task.parent_remote_id {
                 if let Some(parent) =
-                    TaskRepository::get_by_remote_id(&txn, &self.backend_uuid, remote_parent_id).await?
+                    TaskRepository::get_by_remote_id(conn, &self.backend_uuid, remote_parent_id).await?
                 {
                     if let Some(task) =
-                        TaskRepository::get_by_remote_id(&txn, &self.backend_uuid, &backend_task.remote_id).await?
+                        TaskRepository::get_by_remote_id(conn, &self.backend_uuid, &backend_task.remote_id).await?
                     {
                         let mut active_model: task::ActiveModel = task.into();
                         active_model.parent_uuid = ActiveValue::Set(Some(parent.uuid));
-                        TaskRepository::update(&txn, active_model).await?;
+                        TaskRepository::update(conn, active_model).await?;
                     }
                 }
             }
@@ -263,11 +335,11 @@ impl SyncService {
         // Delete task-label relationships only for tasks being synced
         for backend_task in tasks {
             if let Some(task) =
-                TaskRepository::get_by_remote_id(&txn, &self.backend_uuid, &backend_task.remote_id).await?
+                TaskRepository::get_by_remote_id(conn, &self.backend_uuid, &backend_task.remote_id).await?
             {
                 task_label::Entity::delete_many()
                     .filter(task_label::Column::TaskUuid.eq(task.uuid))
-                    .exec(&txn)
+                    .exec(conn)
                     .await?;
             }
         }
@@ -277,7 +349,7 @@ impl SyncService {
             if !label_names.is_empty() {
                 // Find label UUIDs by names
                 for label_name in label_names {
-                    if let Some(label) = LabelRepository::get_by_name(&txn, &label_name).await? {
+                    if let Some(label) = LabelRepository::get_by_name(conn, &label_name).await? {
                         let task_label_relation = task_label::ActiveModel {
                             task_uuid: ActiveValue::Set(task_uuid),
                             label_uuid: ActiveValue::Set(label.uuid),
@@ -291,31 +363,31 @@ impl SyncService {
                                 .do_nothing()
                                 .to_owned(),
                             )
-                            .exec(&txn)
+                            .exec(conn)
                             .await?;
                     }
                 }
             }
         }
 
-        txn.commit().await?;
         Ok(())
     }
 
     /// Store sections in batch
-    pub(super) async fn store_sections_batch(
+    pub(super) async fn store_sections_batch<C>(
         &self,
-        storage: &LocalStorage,
+        conn: &C,
         sections: &[crate::backend::BackendSection],
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
         use sea_orm::sea_query::OnConflict;
-
-        let txn = storage.conn.begin().await?;
 
         for backend_section in sections {
             // Look up local project UUID from remote project_id
             let project_uuid = Self::lookup_project_uuid(
-                &txn,
+                conn,
                 &self.backend_uuid,
                 &backend_section.project_remote_id,
                 "section sync",
@@ -337,10 +409,9 @@ impl SyncService {
                     .update_columns([section::Column::Name, section::Column::ProjectUuid, section::Column::OrderIndex])
                     .to_owned(),
             );
-            insert.exec(&txn).await?;
+            insert.exec(conn).await?;
         }
 
-        txn.commit().await?;
         Ok(())
     }
 
@@ -387,5 +458,136 @@ impl SyncService {
     pub(super) async fn get_label_remote_id(&self, label_uuid: &Uuid) -> Result<String> {
         let storage = self.storage.lock().await;
         LabelRepository::get_remote_id(&storage.conn, label_uuid).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::{BackendProject, BackendSection};
+    use crate::backend_registry::BackendRegistry;
+    use crate::entities::backend;
+    use sea_orm::{EntityTrait, Set};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    #[tokio::test]
+    async fn failed_snapshot_write_preserves_the_previous_cache() {
+        let db_path = std::env::temp_dir().join(format!("terminalist-snapshot-{}.db", Uuid::new_v4()));
+        let storage = LocalStorage::new_at(db_path.clone()).await.unwrap();
+        let backend_uuid = Uuid::new_v4();
+
+        backend::Entity::insert(backend::ActiveModel {
+            uuid: Set(backend_uuid),
+            backend_type: Set("test".to_string()),
+            name: Set("Test".to_string()),
+            is_enabled: Set(true),
+            credentials: Set("{}".to_string()),
+            settings: Set("{}".to_string()),
+        })
+        .exec(&storage.conn)
+        .await
+        .unwrap();
+
+        let storage = Arc::new(Mutex::new(storage));
+        let service = SyncService {
+            backend_registry: Arc::new(BackendRegistry::new(storage.clone())),
+            backend_uuid,
+            storage: storage.clone(),
+            sync_in_progress: Arc::new(Mutex::new(false)),
+            debug_mode: false,
+        };
+
+        let cached_project = BackendProject {
+            remote_id: "cached-project".to_string(),
+            name: "Cached project".to_string(),
+            is_favorite: false,
+            is_inbox: false,
+            order_index: 1,
+            parent_remote_id: None,
+        };
+        {
+            let storage = storage.lock().await;
+            service
+                .store_snapshot(&storage, std::slice::from_ref(&cached_project), &[], &[], &[])
+                .await
+                .unwrap();
+        }
+
+        let replacement_project = BackendProject {
+            remote_id: "replacement-project".to_string(),
+            name: "Replacement project".to_string(),
+            order_index: 2,
+            ..cached_project
+        };
+        let invalid_section = BackendSection {
+            remote_id: "invalid-section".to_string(),
+            name: "Invalid section".to_string(),
+            project_remote_id: "missing-project".to_string(),
+            order_index: 1,
+        };
+        {
+            let storage = storage.lock().await;
+            let result = service
+                .store_snapshot(&storage, &[replacement_project], &[], &[invalid_section], &[])
+                .await;
+            assert!(result.is_err());
+
+            let projects = ProjectRepository::get_all(&storage.conn).await.unwrap();
+            assert_eq!(projects.len(), 1);
+            assert_eq!(projects[0].remote_id, "cached-project");
+        }
+
+        storage.lock().await.conn.clone().close().await.unwrap();
+        std::fs::remove_file(db_path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn successful_snapshot_removes_objects_missing_from_backend() {
+        let db_path = std::env::temp_dir().join(format!("terminalist-replace-snapshot-{}.db", Uuid::new_v4()));
+        let storage = LocalStorage::new_at(db_path.clone()).await.unwrap();
+        let backend_uuid = Uuid::new_v4();
+
+        backend::Entity::insert(backend::ActiveModel {
+            uuid: Set(backend_uuid),
+            backend_type: Set("test".to_string()),
+            name: Set("Test".to_string()),
+            is_enabled: Set(true),
+            credentials: Set("{}".to_string()),
+            settings: Set("{}".to_string()),
+        })
+        .exec(&storage.conn)
+        .await
+        .unwrap();
+
+        let storage = Arc::new(Mutex::new(storage));
+        let service = SyncService::new_for_test(storage.clone(), backend_uuid);
+        let old_project = BackendProject {
+            remote_id: "old-project".to_string(),
+            name: "Old project".to_string(),
+            is_favorite: false,
+            is_inbox: false,
+            order_index: 1,
+            parent_remote_id: None,
+        };
+        let new_project = BackendProject {
+            remote_id: "new-project".to_string(),
+            name: "New project".to_string(),
+            order_index: 2,
+            ..old_project.clone()
+        };
+
+        {
+            let storage = storage.lock().await;
+            service.store_snapshot(&storage, &[old_project], &[], &[], &[]).await.unwrap();
+            service.store_snapshot(&storage, &[new_project], &[], &[], &[]).await.unwrap();
+
+            let projects = ProjectRepository::get_all(&storage.conn).await.unwrap();
+            assert_eq!(projects.len(), 1);
+            assert_eq!(projects[0].remote_id, "new-project");
+        }
+
+        storage.lock().await.conn.clone().close().await.unwrap();
+        std::fs::remove_file(db_path).unwrap();
     }
 }

--- a/src/ui/app_component.rs
+++ b/src/ui/app_component.rs
@@ -156,12 +156,14 @@ impl AppComponent {
             self.schedule_initial_data_fetch();
             self.is_initial_sync = false;
         } else {
-            info!("AppComponent: Starting initial sync");
+            info!("AppComponent: Loading cached data before initial sync");
             if self.active_sync_task.is_none() {
                 self.is_initial_sync = true;
+                self.schedule_initial_data_fetch();
                 self.start_background_sync();
-                // Data fetch will be triggered automatically when sync completes
-                info!("AppComponent: Initial sync scheduled");
+                // A successful sync refreshes the view again. A failed sync leaves the
+                // already-scheduled cached snapshot visible.
+                info!("AppComponent: Cached data load and initial sync scheduled");
             }
         }
     }
@@ -466,13 +468,21 @@ impl AppComponent {
                 self.active_sync_task = None;
                 self.state.loading = false;
 
-                // Extract data from sync status and update components
-                self.update_data_from_sync(status);
-                self.sync_component_data();
-
-                self.state.info_message = Some(SUCCESS_SYNC_COMPLETED.to_string());
-                info!("Sync: Showing completion info dialog");
-                Action::ShowDialog(DialogType::Info(self.state.info_message.clone().unwrap()))
+                match status {
+                    SyncStatus::Success => {
+                        self.update_data_from_sync(SyncStatus::Success);
+                        self.sync_component_data();
+                        self.state.info_message = Some(SUCCESS_SYNC_COMPLETED.to_string());
+                        info!("Sync: Showing completion info dialog");
+                        Action::ShowDialog(DialogType::Info(self.state.info_message.clone().unwrap()))
+                    }
+                    SyncStatus::Error { message } => {
+                        self.is_initial_sync = false;
+                        self.state.error_message = Some(message);
+                        Action::ShowDialog(DialogType::Error(self.state.error_message.clone().unwrap_or_default()))
+                    }
+                    SyncStatus::Idle | SyncStatus::InProgress => Action::None,
+                }
             }
             Action::SyncFailed(error) => {
                 info!("Sync: Failed with error: {}", error);
@@ -1322,5 +1332,71 @@ impl AppComponent {
 
         f.render_widget(Clear, popup_area);
         f.render_widget(content, popup_area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entities::{backend, project};
+    use crate::storage::LocalStorage;
+    use sea_orm::{EntityTrait, Set};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    #[tokio::test]
+    async fn startup_loads_cached_data_when_the_backend_is_unavailable() {
+        let db_path = std::env::temp_dir().join(format!("terminalist-offline-{}.db", Uuid::new_v4()));
+        let storage = LocalStorage::new_at(db_path.clone()).await.unwrap();
+        let backend_uuid = Uuid::new_v4();
+
+        backend::Entity::insert(backend::ActiveModel {
+            uuid: Set(backend_uuid),
+            backend_type: Set("test".to_string()),
+            name: Set("Unavailable backend".to_string()),
+            is_enabled: Set(true),
+            credentials: Set("{}".to_string()),
+            settings: Set("{}".to_string()),
+        })
+        .exec(&storage.conn)
+        .await
+        .unwrap();
+        project::Entity::insert(project::ActiveModel {
+            uuid: Set(Uuid::new_v4()),
+            backend_uuid: Set(backend_uuid),
+            remote_id: Set("cached-project".to_string()),
+            name: Set("Cached project".to_string()),
+            is_favorite: Set(false),
+            is_inbox_project: Set(false),
+            order_index: Set(1),
+            parent_uuid: Set(None),
+        })
+        .exec(&storage.conn)
+        .await
+        .unwrap();
+
+        let storage = Arc::new(Mutex::new(storage));
+        let sync_service = SyncService::new_for_test(storage.clone(), backend_uuid);
+        let mut app = AppComponent::new(sync_service, Config::default(), Vec::new());
+        app.trigger_initial_sync();
+
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+            let actions = app.process_background_actions();
+            for action in actions {
+                app.handle_app_action(action).await;
+            }
+            if app.total_projects() == 1 && app.state.error_message.is_some() {
+                break;
+            }
+        }
+
+        assert_eq!(app.total_projects(), 1);
+        assert_eq!(app.state.projects[0].name, "Cached project");
+        assert!(app.state.error_message.is_some());
+
+        app.task_manager.cancel_all_tasks();
+        storage.lock().await.conn.clone().close().await.unwrap();
+        std::fs::remove_file(db_path).unwrap();
     }
 }

--- a/src/ui/app_component.rs
+++ b/src/ui/app_component.rs
@@ -1380,17 +1380,24 @@ mod tests {
         let mut app = AppComponent::new(sync_service, Config::default(), Vec::new());
         app.trigger_initial_sync();
 
-        for _ in 0..100 {
-            tokio::task::yield_now().await;
-            let actions = app.process_background_actions();
-            for action in actions {
-                app.handle_app_action(action).await;
+        let startup_result = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let actions = app.process_background_actions();
+                for action in actions {
+                    app.handle_app_action(action).await;
+                }
+                if app.total_projects() == 1 && app.state.error_message.is_some() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             }
-            if app.total_projects() == 1 && app.state.error_message.is_some() {
-                break;
-            }
-        }
+        })
+        .await;
 
+        assert!(
+            startup_result.is_ok(),
+            "cached startup did not finish within five seconds"
+        );
         assert_eq!(app.total_projects(), 1);
         assert_eq!(app.state.projects[0].name, "Cached project");
         assert!(app.state.error_message.is_some());

--- a/tests/storage/db.rs
+++ b/tests/storage/db.rs
@@ -1,8 +1,31 @@
+use sea_orm::{ConnectionTrait, DbBackend, Statement};
 use terminalist::storage::LocalStorage;
 
 #[tokio::test]
 async fn test_local_storage_creation() {
-    // Test that we can create local storage (use in-memory database for tests)
-    let result = LocalStorage::new(false).await;
-    assert!(result.is_ok(), "LocalStorage should be created successfully");
+    let db_path = std::env::temp_dir().join(format!("terminalist-storage-{}.db", uuid::Uuid::new_v4()));
+
+    let first = LocalStorage::new_at(db_path.clone())
+        .await
+        .expect("first LocalStorage should be created successfully");
+    let second = LocalStorage::new_at(db_path.clone())
+        .await
+        .expect("second LocalStorage should reuse the existing database");
+
+    // A second startup must not replace the file underneath the first connection.
+    first
+        .conn
+        .execute(Statement::from_string(
+            DbBackend::Sqlite,
+            "INSERT INTO backends \
+             (uuid, backend_type, name, is_enabled, credentials, settings) \
+             VALUES ('00000000-0000-0000-0000-000000000001', 'test', 'Test', 1, '{}', '{}')"
+                .to_owned(),
+        ))
+        .await
+        .expect("first connection should remain writable after the second startup");
+
+    first.conn.close().await.expect("first connection should close");
+    second.conn.close().await.expect("second connection should close");
+    std::fs::remove_file(db_path).expect("test database should be removed");
 }


### PR DESCRIPTION
## Summary

- retain the SQLite cache between normal application runs
- load cached projects and tasks immediately while the initial Todoist sync runs
- keep cached data visible when startup sync or cache refresh fails
- reuse the persisted Todoist backend record instead of creating a duplicate on every launch
- replace successful remote snapshots atomically so remotely removed objects do not linger

## Why

Terminalist currently deletes its cache during ordinary startup. That makes startup depend on a successful Todoist request, leaves the UI without useful data when the network is unavailable, and can invalidate a database file that another running process still has open.

The cache is now durable. Remote data is fetched before beginning a database transaction, and the backend-specific snapshot is replaced within that transaction. A failed write rolls back to the last usable cache; a failed remote sync leaves the cached view intact.

## User impact

Users see their cached task data immediately at startup and can still inspect it if Todoist is temporarily unavailable. Successful syncs continue to refresh the cache authoritatively.

## Validation

- `cargo fmt --all -- --check`
- `cargo test` (59 unit/integration tests and 2 doc tests passed)
- regression coverage for database reuse, offline startup, transactional rollback, and removal of objects absent from a successful snapshot
