### PR TITLE
test(storage): stop asserting the temp database can be deleted

### DIFF
--- a/tests/storage/db.rs
+++ b/tests/storage/db.rs
@@ -27,7 +27,9 @@ async fn test_local_storage_creation() {
 
     first.conn.close().await.expect("first connection should close");
     second.conn.close().await.expect("second connection should close");
-    std::fs::remove_file(db_path).expect("test database should be removed");
+    // Best-effort: sqlx closes the sqlite handle on a worker thread that can outlive
+    // pool.close(), and Windows refuses to unlink a file that still has one open.
+    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
@@ -98,7 +100,9 @@ async fn test_stale_schema_version_rebuilds_cache() {
     );
 
     reopened.conn.close().await.expect("connection should close");
-    std::fs::remove_file(db_path).expect("test database should be removed");
+    // Best-effort: sqlx closes the sqlite handle on a worker thread that can outlive
+    // pool.close(), and Windows refuses to unlink a file that still has one open.
+    let _ = std::fs::remove_file(db_path);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
The Windows job fails intermittently with "The process cannot access the file because it is being used by another process". The tests already await conn.close(), and sea-orm awaits pool.close() underneath, but sqlx finishes sqlite3_close on a worker thread that can outlive it. Windows then refuses to unlink the file; POSIX does not care, which is why only Windows sees this.

Whether a temp file can be removed is not what these tests are about, so the cleanup is best-effort now.
