### PR TITLE
feat(sync): honour auto_sync_interval_minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Periodic auto-sync** - `auto_sync_interval_minutes` is now actually honoured; until now the key was read from the config file and then ignored. Defaults to every 5 minutes, `0` disables it and leaves syncing manual.
+
 ### Security
 - **Cache file permissions** - The local SQLite cache stores the Todoist API token, and is now created with `0600` so only its owner can read it. Existing cache files are tightened on the next launch.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A terminal application for interacting with Todoist, built in Rust with a modern
 
 - **Interactive TUI Interface** - Beautiful terminal user interface with ratatui
 - **Local Data Caching** - Fast, responsive UI backed by a local SQLite cache that survives restarts
-- **Smart Sync** - Automatic sync on startup and manual refresh with 'r'
+- **Smart Sync** - Automatic sync on startup, on a configurable interval, and manual refresh with 'r'
 - **Project Management** - Browse projects with hierarchical display
 - **Task Management** - View, navigate, complete, and create tasks
 - **Task Search** - Fast database-powered search across all tasks with '/' shortcut
@@ -130,6 +130,7 @@ Essential keyboard shortcuts to get started:
 Terminalist uses a smart sync mechanism:
 - **Fast Startup**: Cached data from the last run is shown instantly while the sync runs
 - **Startup Sync**: Syncs with Todoist once on startup, in the background
+- **Periodic Sync**: Re-syncs every `auto_sync_interval_minutes` (5 by default, `0` disables it)
 - **Manual Sync**: Press `r` to force refresh from Todoist
 - **Real-time Updates**: Create, modify, and delete tasks/projects immediately
 

--- a/src/ui/app_component.rs
+++ b/src/ui/app_component.rs
@@ -18,6 +18,7 @@ use ratatui::{
     layout::{Constraint, Layout, Rect},
     Frame,
 };
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -80,6 +81,7 @@ pub struct AppComponent {
     should_quit: bool,
     active_sync_task: Option<TaskId>,
     is_initial_sync: bool,
+    last_sync_attempt: Option<Instant>,
 
     // Layout state
     sidebar_visible: bool,
@@ -117,6 +119,7 @@ impl AppComponent {
             should_quit: false,
             active_sync_task: None,
             is_initial_sync: false,
+            last_sync_attempt: None,
             sidebar_width: 30, // Default width
             screen_width: 100, // Default width
             screen_height: 50, // Default height
@@ -851,7 +854,19 @@ impl AppComponent {
         }
     }
 
+    /// Whether the configured auto-sync interval has elapsed since the last attempt.
+    ///
+    /// The stamp is taken when a sync *starts*, so a backend that fails fast can't re-fire
+    /// on every tick. It stays `None` in debug mode, where no sync ever runs.
+    fn auto_sync_due(&self) -> bool {
+        let interval = Duration::from_secs(self.config.sync.auto_sync_interval_minutes * 60);
+        !interval.is_zero()
+            && self.active_sync_task.is_none()
+            && self.last_sync_attempt.is_some_and(|at| at.elapsed() >= interval)
+    }
+
     fn start_background_sync(&mut self) {
+        self.last_sync_attempt = Some(Instant::now());
         let sync_service = self.sync_service.clone();
         let task_id = self.task_manager.spawn_sync(sync_service);
         self.active_sync_task = Some(task_id);
@@ -1136,6 +1151,11 @@ impl AppComponent {
         while let Ok(action) = self.background_action_rx.try_recv() {
             info!("Background: Received action {:?}", action);
             actions.push(action);
+        }
+
+        if self.auto_sync_due() {
+            info!("Auto-sync: interval elapsed, queueing sync");
+            actions.push(Action::StartSync);
         }
 
         // Clean up finished tasks


### PR DESCRIPTION
The config key was deserialized, defaulted to 5 and validated against 1440, but no runtime code ever read it. The tick path now queues a sync once the interval has elapsed since the last attempt.

The timestamp is stamped when a sync starts rather than when it finishes, so a backend that fails fast cannot re-fire on every tick. It stays unset in debug mode, where no sync ever runs, which keeps auto-sync off there too.

## Changes
- [x] Code changes
- [ ] Tests added/updated
- [x] Docs updated (README/CHANGELOG)

## Checklist
- [ ] `cargo fmt` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes


