### PR TITLE
fix(ui): stop losing tasks whose text contains a pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Sync status toast** - Replace blocking sync dialog with a toast.
 
+### Fixed
+- **Pipes in task and project names** - Creating a task or project whose text contained a `|` failed outright, because the name and the parent id were packed into one string that got split on the first separator. The id now comes first, so your text keeps whatever you typed.
+
 ### Security
 - **Cache file permissions** - The local SQLite cache stores the Todoist API token, and is now created with `0600` so only its owner can read it. Existing cache files are tightened on the next launch.
 

--- a/src/ui/app_component.rs
+++ b/src/ui/app_component.rs
@@ -8,6 +8,7 @@ use crate::ui::core::SidebarSelection;
 use crate::ui::core::{
     actions::{Action, DialogType},
     event_handler::EventType,
+    operations::{pack_owned, unpack_owned},
     task_manager::{TaskId, TaskManager},
     Component,
 };
@@ -525,12 +526,7 @@ impl AppComponent {
                 };
                 info!("Task: Creating task with content '{}'{}", content, project_desc);
 
-                // Format task info to include both content and project_uuid
-                let task_info = match project_uuid {
-                    Some(pid) => format!("{}|{}", content, pid),
-                    None => content,
-                };
-                self.spawn_task_operation("Create task".to_string(), task_info);
+                self.spawn_task_operation("Create task".to_string(), pack_owned(project_uuid, &content));
                 Action::None
             }
             Action::CompleteTask(task_id) => {
@@ -667,12 +663,7 @@ impl AppComponent {
                 };
                 info!("Project: Creating project '{}'{}", name, parent_desc);
 
-                // Format project info to include both name and parent_uuid
-                let project_info = match parent_uuid {
-                    Some(pid) => format!("{}|{}", name, pid),
-                    None => name,
-                };
-                self.spawn_task_operation("Create project".to_string(), project_info);
+                self.spawn_task_operation("Create project".to_string(), pack_owned(parent_uuid, &name));
                 Action::None
             }
             Action::DeleteProject(project_id) => {
@@ -976,25 +967,20 @@ impl AppComponent {
                             Err(ERROR_INVALID_DATE_FORMAT.to_string())
                         }
                     }
-                    "Create task" => {
-                        // task_info format: "content|project_id" or just "content" for inbox
-                        if let Some((content, project_id_str)) = task_info.split_once('|') {
-                            // Task has a specific project - parse the UUID
-                            match Uuid::parse_str(project_id_str) {
-                                Ok(project_uuid) => match sync_service.create_task(content, Some(project_uuid)).await {
-                                    Ok(()) => Ok(format!("{}: {}", SUCCESS_TASK_CREATED_PROJECT, content)),
-                                    Err(e) => Err(format!("{}: {}", ERROR_TASK_CREATE_FAILED, e)),
-                                },
-                                Err(e) => Err(format!("Invalid project UUID: {}", e)),
-                            }
-                        } else {
-                            // Task goes to inbox (no project_id)
-                            match sync_service.create_task(&task_info, None).await {
-                                Ok(()) => Ok(format!("{}: {}", SUCCESS_TASK_CREATED_INBOX, task_info)),
+                    "Create task" => match unpack_owned(&task_info) {
+                        Ok((project_uuid, content)) => {
+                            let landed = if project_uuid.is_some() {
+                                SUCCESS_TASK_CREATED_PROJECT
+                            } else {
+                                SUCCESS_TASK_CREATED_INBOX
+                            };
+                            match sync_service.create_task(content, project_uuid).await {
+                                Ok(()) => Ok(format!("{}: {}", landed, content)),
                                 Err(e) => Err(format!("{}: {}", ERROR_TASK_CREATE_FAILED, e)),
                             }
                         }
-                    }
+                        Err(e) => Err(format!("Invalid project UUID: {}", e)),
+                    },
                     "Edit task" => {
                         // task_info format: "task_id: new_content"
                         if let Some((task_id_str, content)) = task_info.split_once(": ") {
@@ -1016,25 +1002,20 @@ impl AppComponent {
                         },
                         Err(e) => Err(format!("Invalid task UUID: {}", e)),
                     },
-                    "Create project" => {
-                        // project_info format: "name|parent_id" or just "name" for root project
-                        if let Some((name, parent_id_str)) = task_info.split_once('|') {
-                            // Project has a parent - parse the UUID
-                            match Uuid::parse_str(parent_id_str) {
-                                Ok(parent_uuid) => match sync_service.create_project(name, Some(parent_uuid)).await {
-                                    Ok(()) => Ok(format!("{}: {}", SUCCESS_PROJECT_CREATED_PARENT, name)),
-                                    Err(e) => Err(format!("{}: {}", ERROR_PROJECT_CREATE_FAILED, e)),
-                                },
-                                Err(e) => Err(format!("Invalid parent project UUID: {}", e)),
-                            }
-                        } else {
-                            // Root project (no parent)
-                            match sync_service.create_project(&task_info, None).await {
-                                Ok(()) => Ok(format!("{}: {}", SUCCESS_PROJECT_CREATED_ROOT, task_info)),
+                    "Create project" => match unpack_owned(&task_info) {
+                        Ok((parent_uuid, name)) => {
+                            let landed = if parent_uuid.is_some() {
+                                SUCCESS_PROJECT_CREATED_PARENT
+                            } else {
+                                SUCCESS_PROJECT_CREATED_ROOT
+                            };
+                            match sync_service.create_project(name, parent_uuid).await {
+                                Ok(()) => Ok(format!("{}: {}", landed, name)),
                                 Err(e) => Err(format!("{}: {}", ERROR_PROJECT_CREATE_FAILED, e)),
                             }
                         }
-                    }
+                        Err(e) => Err(format!("Invalid parent project UUID: {}", e)),
+                    },
                     "Delete project" => {
                         // task_info is a UUID string
                         match Uuid::parse_str(&task_info) {

--- a/src/ui/core/mod.rs
+++ b/src/ui/core/mod.rs
@@ -10,6 +10,7 @@
 //! - [`component`] - Base component trait and rendering abstractions
 //! - [`context`] - Application context and shared state management
 //! - [`event_handler`] - Event processing and keyboard/mouse input handling
+//! - [`operations`] - Argument encoding for background operations
 //! - [`task_manager`] - Background task management and async operation handling
 //!
 //! # Architecture
@@ -30,6 +31,7 @@ pub mod actions;
 pub mod component;
 pub mod context;
 pub mod event_handler;
+pub mod operations;
 pub mod task_manager;
 
 // Re-export core types for easier access from other modules

--- a/src/ui/core/operations.rs
+++ b/src/ui/core/operations.rs
@@ -1,0 +1,31 @@
+//! Argument encoding for background operations.
+//!
+//! Background operations are dispatched by name, with their arguments squeezed into a
+//! single string. Wherever that string carries free-form user text next to a uuid, the
+//! uuid has to come first: a uuid can never contain the separator, so whatever
+//! punctuation the user typed survives the round trip.
+
+use uuid::Uuid;
+
+/// Separator between a uuid and the free text that follows it.
+const SEP: char = '|';
+
+/// Packs an optional owner uuid ahead of free-form text. The empty prefix means "no
+/// owner", which is why the separator is always written.
+#[must_use]
+pub fn pack_owned(owner: Option<Uuid>, text: &str) -> String {
+    match owner {
+        Some(uuid) => format!("{uuid}{SEP}{text}"),
+        None => format!("{SEP}{text}"),
+    }
+}
+
+/// Splits what [`pack_owned`] produced back apart. The text comes back verbatim,
+/// separators included, because only the first separator is significant.
+pub fn unpack_owned(packed: &str) -> Result<(Option<Uuid>, &str), uuid::Error> {
+    let (owner, text) = packed.split_once(SEP).unwrap_or(("", packed));
+    if owner.is_empty() {
+        return Ok((None, text));
+    }
+    Ok((Some(Uuid::parse_str(owner)?), text))
+}

--- a/tests/ui/core.rs
+++ b/tests/ui/core.rs
@@ -10,5 +10,8 @@ mod context;
 #[path = "core/event_handler.rs"]
 mod event_handler;
 
+#[path = "core/operations.rs"]
+mod operations;
+
 #[path = "core/task_manager.rs"]
 mod task_manager;

--- a/tests/ui/core/operations.rs
+++ b/tests/ui/core/operations.rs
@@ -1,0 +1,37 @@
+//! The encoding that carries an optional owner uuid next to free-form user text.
+//! User text is the untrusted half here, so the separator has to survive inside it.
+
+use terminalist::ui::core::operations::{pack_owned, unpack_owned};
+use uuid::Uuid;
+
+/// A pipe in the user's text used to eat the uuid and break creation outright.
+#[test]
+fn text_keeps_its_separators() {
+    let owner = Uuid::new_v4();
+    for text in [
+        "review PR | urgent",
+        "|leading",
+        "trailing|",
+        "a|b|c|d",
+        "|||",
+        "",
+        "plain text",
+        "name: with a colon",
+    ] {
+        let owned = pack_owned(Some(owner), text);
+        let (got_owner, got_text) = unpack_owned(&owned).unwrap();
+        assert_eq!(got_owner, Some(owner), "owner lost for {text:?}");
+        assert_eq!(got_text, text, "text mangled for {text:?}");
+
+        let ownerless = pack_owned(None, text);
+        let (no_owner, got_text) = unpack_owned(&ownerless).unwrap();
+        assert_eq!(no_owner, None, "phantom owner for {text:?}");
+        assert_eq!(got_text, text, "text mangled for {text:?}");
+    }
+}
+
+/// A garbled uuid has to surface as an error, not as a silently ownerless item.
+#[test]
+fn a_bad_owner_uuid_is_an_error() {
+    assert!(unpack_owned("not-a-uuid|some text").is_err());
+}


### PR DESCRIPTION
## The bug

Creating a task whose text contains a `|` failed silently. `Action::CreateTask` packed its arguments into one string as `"{content}|{project_uuid}"`, and the handler split on the **first** separator:

```
content = "review PR | urgent", in a project
  → "review PR | urgent|<uuid>"
  → split_once('|') → ("review PR ", " urgent|<uuid>")
  → Uuid::parse_str(" urgent|<uuid>") fails
  → "Invalid project UUID", task never created
```

The inbox case was worse. With no project at all, any text containing a pipe still split successfully, so the code tried to parse the tail as a uuid and failed on a task that had no project to begin with.

`Action::CreateProject` had the same shape for parent projects.

Every other operation was already safe: they all put the uuid first, and a uuid can never contain `|` or `: `.

## The fix

New `src/ui/core/operations.rs` owns the encoding:

```rust
pub fn pack_owned(owner: Option<Uuid>, text: &str) -> String
pub fn unpack_owned(packed: &str) -> Result<(Option<Uuid>, &str), uuid::Error>
```

The uuid goes first, and the separator is always written so an empty prefix means "no owner". Everything after the first separator is text, verbatim.

Both call sites and both handlers go through it. That also drops two nested `if let` / `match` ladders, so `app_component.rs` loses 44 lines and gains 25.

## Tests

`tests/ui/core/operations.rs` round-trips `"review PR | urgent"`, `"|leading"`, `"trailing|"`, `"a|b|c|d"`, `"|||"`, `""` and a colon case through both owner states, plus a malformed-uuid case that has to surface as an error rather than a silently ownerless item.

Confirmed non-vacuous: flipping the encoding back to the old order makes `text_keeps_its_separators` fail, and it passes again once restored.

## Notes

`ui::core::operations` is deliberately where the operation dispatch should end up. Operations are currently dispatched by name with arguments squeezed into a string, which is what made this bug possible in the first place; a follow-up can replace that with an `Operation` enum and delete the encoding entirely. This PR only fixes the reachable bug.
