### PR TITLE
refactor(ui): dispatch background work through an Operation enum

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -45,13 +45,6 @@ pub const ERROR_LABEL_UPDATE_FAILED: &str = "❌ Failed to update label";
 pub const ERROR_TASK_RESTORE_FAILED: &str = "❌ Failed to restore task";
 
 // Validation Error Messages
-pub const ERROR_INVALID_PRIORITY_FORMAT: &str = "❌ Invalid priority value format";
-pub const ERROR_INVALID_PRIORITY_INFO: &str = "❌ Invalid task priority info format";
-pub const ERROR_INVALID_DATE_FORMAT: &str = "❌ Invalid task info format for setting due date";
-pub const ERROR_INVALID_TASK_EDIT_FORMAT: &str = "❌ Invalid task edit format";
-pub const ERROR_INVALID_PROJECT_EDIT_FORMAT: &str = "❌ Invalid project edit format";
-pub const ERROR_INVALID_LABEL_EDIT_FORMAT: &str = "❌ Invalid label edit format";
-pub const ERROR_UNKNOWN_OPERATION: &str = "❌ Unknown operation";
 
 // Log Messages
 

--- a/src/ui/app_component/mod.rs
+++ b/src/ui/app_component/mod.rs
@@ -10,11 +10,10 @@ use crate::ui::core::SidebarSelection;
 use crate::ui::core::{
     actions::{Action, DialogType},
     event_handler::EventType,
-    operations::{pack_owned, unpack_owned},
+    operations::{Due, Operation},
     task_manager::{TaskId, TaskManager},
     Component,
 };
-use crate::utils::datetime;
 use crossterm::event::KeyEvent;
 use log::info;
 use ratatui::{
@@ -298,199 +297,114 @@ impl AppComponent {
             }
             // Task operations with background execution
             Action::CreateTask { content, project_uuid } => {
-                let project_desc = match &project_uuid {
-                    Some(uuid) => format!(" in project {}", uuid),
-                    None => " in inbox".to_string(),
-                };
-                info!("Task: Creating task with content '{}'{}", content, project_desc);
-
-                self.spawn_task_operation("Create task".to_string(), pack_owned(project_uuid, &content));
+                match project_uuid {
+                    Some(uuid) => info!("Task: Creating '{}' in project {}", content, uuid),
+                    None => info!("Task: Creating '{}' in inbox", content),
+                }
+                self.spawn(Operation::CreateTask {
+                    content,
+                    project: project_uuid,
+                });
                 Action::None
             }
-            Action::CompleteTask(task_id) => {
-                // Find the task being completed
-                let sync_service = self.sync_service.clone();
-                if let Ok(task_uuid) = Uuid::parse_str(&task_id) {
-                    if let Ok(Some(task)) = sync_service.get_task_by_id(&task_uuid).await {
-                        let task_desc = format!("ID {} '{}'", task_id, task.content);
-
-                        info!("Task: Completing task {}", task_desc);
-
-                        // Todoist API automatically handles subtasks when parent is completed
-                        self.spawn_task_operation("Complete task".to_string(), task_id);
-                    } else {
-                        info!("Task: Cannot complete - task {} not found", task_id);
+            Action::CompleteTask(task) => {
+                // Kept from before the operations rework: a task storage does not know about
+                // is not sent. See the note in the PR about that silently doing nothing.
+                let existing = self.sync_service.get_task_by_id(&task).await;
+                match existing {
+                    Ok(Some(found)) => {
+                        info!("Task: Completing ID {} '{}'", task, found.content);
+                        // The backend completes subtasks along with their parent.
+                        self.spawn(Operation::CompleteTask(task));
                     }
-                } else {
-                    info!("Task: Cannot complete - invalid UUID {}", task_id);
+                    Ok(None) => info!("Task: Cannot complete, task {} not found", task),
+                    Err(e) => info!("Task: Cannot complete task {}: {}", task, e),
                 }
                 Action::None
             }
-            Action::CyclePriority(task_id) => {
-                // Find task and cycle its priority
-                let sync_service = self.sync_service.clone();
-                if let Ok(task_uuid) = Uuid::parse_str(&task_id) {
-                    if let Ok(Some(task)) = sync_service.get_task_by_id(&task_uuid).await {
-                        // Todoist priorities: 1 (Normal), 2 (High), 3 (Higher), 4 (Highest)
-                        let new_priority = match task.priority {
-                            4 => 1,                 // Highest -> Normal
-                            _ => task.priority + 1, // Normal/High/Higher -> next level
-                        };
-                        let task_desc = format!(
-                            "ID {} '{}' (P{} -> P{})",
-                            task_id, task.content, task.priority, new_priority
+            Action::CyclePriority(task) => {
+                // The current priority has to come from storage: state.tasks holds whatever
+                // the active view last loaded, which is not necessarily this task.
+                let existing = self.sync_service.get_task_by_id(&task).await;
+                match existing {
+                    Ok(Some(current)) => {
+                        // 1 (Normal) through 4 (Highest), then back around.
+                        let priority = if current.priority == 4 { 1 } else { current.priority + 1 };
+                        info!(
+                            "Task: Cycling priority for {} (P{} -> P{})",
+                            self.describe_task(task),
+                            current.priority,
+                            priority
                         );
-                        info!("Task: Cycling priority for task {}", task_desc);
-                        self.spawn_task_operation(
-                            "Cycle priority".to_string(),
-                            format!("{}|{}", task_id, new_priority),
-                        );
-                    } else {
-                        info!("Task: Cannot cycle priority - task {} not found", task_id);
+                        self.spawn(Operation::CyclePriority { task, priority });
                     }
-                } else {
-                    info!("Task: Cannot cycle priority - invalid UUID {}", task_id);
+                    Ok(None) => info!("Task: Cannot cycle priority, task {} not found", task),
+                    Err(e) => info!("Task: Cannot cycle priority for task {}: {}", task, e),
                 }
                 Action::None
             }
-            Action::DeleteTask(task_id) => {
-                // Find task name for better logging
-                let sync_service = self.sync_service.clone();
-                let task_desc = if let Ok(task_uuid) = Uuid::parse_str(&task_id) {
-                    if let Ok(Some(task)) = sync_service.get_task_by_id(&task_uuid).await {
-                        format!("ID {} '{}'", task_id, task.content)
-                    } else {
-                        format!("ID {} [unknown]", task_id)
-                    }
-                } else {
-                    format!("ID {} [invalid UUID]", task_id)
-                };
-                info!("Task: Deleting task {}", task_desc);
-                self.spawn_task_operation("Delete task".to_string(), task_id);
+            Action::DeleteTask(task) => {
+                info!("Task: Deleting {}", self.describe_task(task));
+                self.spawn(Operation::DeleteTask(task));
                 Action::None
             }
-            Action::SetTaskDueToday(task_id) => {
-                // Find task name for better logging
-                let sync_service = self.sync_service.clone();
-                let task_id_str = task_id.to_string();
-                let task_desc = if let Ok(Some(task)) = sync_service.get_task_by_id(&task_id).await {
-                    format!("ID {} '{}'", task_id, task.content)
-                } else {
-                    format!("ID {} [unknown]", task_id)
-                };
-                info!("Task: Setting due date to today for task {}", task_desc);
-                self.spawn_task_operation("Set task due today".to_string(), format!("{}|today", task_id_str));
-                Action::None
-            }
-            Action::SetTaskDueTomorrow(task_id) => {
-                // Find task name for better logging
-                let sync_service = self.sync_service.clone();
-                let task_id_str = task_id.to_string();
-                let task_desc = if let Ok(Some(task)) = sync_service.get_task_by_id(&task_id).await {
-                    format!("ID {} '{}'", task_id, task.content)
-                } else {
-                    format!("ID {} [unknown]", task_id)
-                };
-                info!("Task: Setting due date to tomorrow for task {}", task_desc);
-                self.spawn_task_operation("Set task due tomorrow".to_string(), format!("{}|tomorrow", task_id_str));
-                Action::None
-            }
-            Action::SetTaskDueNextWeek(task_id) => {
-                // Find task name for better logging
-                let sync_service = self.sync_service.clone();
-                let task_id_str = task_id.to_string();
-                let task_desc = if let Ok(Some(task)) = sync_service.get_task_by_id(&task_id).await {
-                    format!("ID {} '{}'", task_id, task.content)
-                } else {
-                    format!("ID {} [unknown]", task_id)
-                };
-                info!("Task: Setting due date to next week for task {}", task_desc);
-                self.spawn_task_operation(
-                    "Set task due next week".to_string(),
-                    format!("{}|next_week", task_id_str),
-                );
-                Action::None
-            }
-            Action::SetTaskDueWeekEnd(task_id) => {
-                // Find task name for better logging
-                let sync_service = self.sync_service.clone();
-                let task_id_str = task_id.to_string();
-                let task_desc = if let Ok(Some(task)) = sync_service.get_task_by_id(&task_id).await {
-                    format!("ID {} '{}'", task_id, task.content)
-                } else {
-                    format!("ID {} [unknown]", task_id)
-                };
-                info!("Task: Setting due date to weekend for task {}", task_desc);
-                self.spawn_task_operation("Set task due weekend".to_string(), format!("{}|weekend", task_id_str));
-                Action::None
-            }
+            Action::SetTaskDueToday(task) => self.set_due(task, Due::Today),
+            Action::SetTaskDueTomorrow(task) => self.set_due(task, Due::Tomorrow),
+            Action::SetTaskDueNextWeek(task) => self.set_due(task, Due::NextWeek),
+            Action::SetTaskDueWeekEnd(task) => self.set_due(task, Due::Weekend),
             Action::EditTask { task_uuid, content } => {
-                info!("Task: Editing task UUID {} with new content '{}'", task_uuid, content);
-                self.spawn_task_operation("Edit task".to_string(), format!("{}: {}", task_uuid, content));
+                info!("Task: Editing {} to '{}'", self.describe_task(task_uuid), content);
+                self.spawn(Operation::EditTask {
+                    task: task_uuid,
+                    content,
+                });
                 Action::None
             }
-            Action::RestoreTask(task_id) => {
-                info!("Task: Restoring task {}", task_id);
-                self.spawn_task_operation("Restore task".to_string(), task_id);
+            Action::RestoreTask(task) => {
+                info!("Task: Restoring {}", self.describe_task(task));
+                self.spawn(Operation::RestoreTask(task));
                 Action::None
             }
             Action::CreateProject { name, parent_uuid } => {
-                let parent_desc = match &parent_uuid {
-                    Some(uuid) => format!(" with parent {}", uuid),
-                    None => "".to_string(),
-                };
-                info!("Project: Creating project '{}'{}", name, parent_desc);
-
-                self.spawn_task_operation("Create project".to_string(), pack_owned(parent_uuid, &name));
+                match parent_uuid {
+                    Some(uuid) => info!("Project: Creating '{}' under {}", name, uuid),
+                    None => info!("Project: Creating '{}' at root", name),
+                }
+                self.spawn(Operation::CreateProject {
+                    name,
+                    parent: parent_uuid,
+                });
                 Action::None
             }
-            Action::DeleteProject(project_id) => {
-                // Find project name for better logging
-                let project_desc = if let Some(project) = self.state.projects.iter().find(|p| p.uuid == project_id) {
-                    format!("ID {} '{}'", project_id, project.name)
-                } else {
-                    format!("ID {} [unknown]", project_id)
-                };
-                info!("Project: Deleting project {}", project_desc);
-                self.spawn_task_operation("Delete project".to_string(), project_id.to_string());
+            Action::DeleteProject(project) => {
+                info!("Project: Deleting {}", self.describe_project(project));
+                self.spawn(Operation::DeleteProject(project));
                 Action::None
             }
-            Action::DeleteLabel(label_id) => {
-                // Find label name for better logging
-                let label_desc = if let Some(label) = self.state.labels.iter().find(|l| l.uuid == label_id) {
-                    format!("ID {} '{}'", label_id, label.name)
-                } else {
-                    format!("ID {} [unknown]", label_id)
-                };
-                info!("Label: Deleting label {}", label_desc);
-                self.spawn_task_operation("Delete label".to_string(), label_id.to_string());
+            Action::DeleteLabel(label) => {
+                info!("Label: Deleting {}", self.describe_label(label));
+                self.spawn(Operation::DeleteLabel(label));
                 Action::None
             }
             Action::CreateLabel { name } => {
-                info!("Label: Creating label '{}'", name);
-                self.spawn_task_operation("Create label".to_string(), name);
+                info!("Label: Creating '{}'", name);
+                self.spawn(Operation::CreateLabel { name });
                 Action::None
             }
             Action::EditProject { project_uuid, name } => {
-                // Find project name for better logging
-                let project_desc = if let Some(project) = self.state.projects.iter().find(|p| p.uuid == project_uuid) {
-                    format!("UUID {} '{}' -> '{}'", project_uuid, project.name, name)
-                } else {
-                    format!("UUID {} [unknown] -> '{}'", project_uuid, name)
-                };
-                info!("Project: Editing project {}", project_desc);
-                self.spawn_task_operation("Edit project".to_string(), format!("{}: {}", project_uuid, name));
+                info!("Project: Editing {} -> '{}'", self.describe_project(project_uuid), name);
+                self.spawn(Operation::EditProject {
+                    project: project_uuid,
+                    name,
+                });
                 Action::None
             }
             Action::EditLabel { label_uuid, name } => {
-                // Find label name for better logging
-                let label_desc = if let Some(label) = self.state.labels.iter().find(|l| l.uuid == label_uuid) {
-                    format!("UUID {} '{}' -> '{}'", label_uuid, label.name, name)
-                } else {
-                    format!("UUID {} [unknown] -> '{}'", label_uuid, name)
-                };
-                info!("Label: Editing label {}", label_desc);
-                self.spawn_task_operation("Edit label".to_string(), format!("{}: {}", label_uuid, name));
+                info!("Label: Editing {} -> '{}'", self.describe_label(label_uuid), name);
+                self.spawn(Operation::EditLabel {
+                    label: label_uuid,
+                    name,
+                });
                 Action::None
             }
             Action::InitialDataLoaded {
@@ -625,236 +539,44 @@ impl AppComponent {
     }
 
     /// Spawn a generic task operation (now with actual API calls and data refresh)
-    fn spawn_task_operation(&mut self, operation_name: String, task_info: String) {
-        let description = format!("{}: {}", operation_name, task_info);
-        let op_name = operation_name.clone();
-        let sync_service = self.sync_service.clone();
+    /// Hands an operation to the background task manager.
+    fn spawn(&mut self, operation: Operation) {
+        let description = operation.describe();
         info!("Background: Spawning task operation '{}'", description);
-
+        let sync_service = self.sync_service.clone();
         let _task_id = self.task_manager.spawn_task_operation(
-            move || async move {
-                let result = match op_name.as_str() {
-                    "Complete task" => match Uuid::parse_str(&task_info) {
-                        Ok(task_uuid) => match sync_service.complete_task(&task_uuid).await {
-                            Ok(()) => Ok(format!("{}: {}", SUCCESS_TASK_COMPLETED, task_info)),
-                            Err(e) => Err(format!("{}: {}", ERROR_TASK_COMPLETION_FAILED, e)),
-                        },
-                        Err(e) => Err(format!("Invalid task UUID: {}", e)),
-                    },
-                    "Delete task" => match Uuid::parse_str(&task_info) {
-                        Ok(task_uuid) => match sync_service.delete_task(&task_uuid).await {
-                            Ok(()) => Ok(format!("{}: {}", SUCCESS_TASK_DELETED, task_info)),
-                            Err(e) => Err(format!("{}: {}", ERROR_TASK_DELETE_FAILED, e)),
-                        },
-                        Err(e) => Err(format!("Invalid task UUID: {}", e)),
-                    },
-                    "Cycle priority" => {
-                        // task_info format: "task_id|new_priority"
-                        if let Some((task_id_str, priority_str)) = task_info.split_once('|') {
-                            match Uuid::parse_str(task_id_str) {
-                                Ok(task_uuid) => {
-                                    if let Ok(priority) = priority_str.parse::<i32>() {
-                                        match sync_service.update_task_priority(&task_uuid, priority).await {
-                                            Ok(()) => Ok(format!(
-                                                "{}{}: {}",
-                                                SUCCESS_TASK_PRIORITY_UPDATED, priority, task_id_str
-                                            )),
-                                            Err(e) => Err(format!("{}: {}", ERROR_TASK_PRIORITY_FAILED, e)),
-                                        }
-                                    } else {
-                                        Err(ERROR_INVALID_PRIORITY_FORMAT.to_string())
-                                    }
-                                }
-                                Err(e) => Err(format!("Invalid task UUID: {}", e)),
-                            }
-                        } else {
-                            Err(ERROR_INVALID_PRIORITY_INFO.to_string())
-                        }
-                    }
-                    "Set task due today" => {
-                        // task_info format: "task_id|today"
-                        if let Some((task_id_str, _)) = task_info.split_once('|') {
-                            match Uuid::parse_str(task_id_str) {
-                                Ok(task_uuid) => {
-                                    let today = datetime::format_today();
-                                    match sync_service.update_task_due_date(&task_uuid, Some(&today)).await {
-                                        Ok(()) => Ok(format!("{}: {}", SUCCESS_TASK_DUE_TODAY, task_id_str)),
-                                        Err(e) => Err(format!("{}: {}", ERROR_TASK_DUE_DATE_FAILED, e)),
-                                    }
-                                }
-                                Err(e) => Err(format!("Invalid task UUID: {}", e)),
-                            }
-                        } else {
-                            Err(ERROR_INVALID_DATE_FORMAT.to_string())
-                        }
-                    }
-                    "Set task due tomorrow" => {
-                        // task_info format: "task_id|tomorrow"
-                        if let Some((task_id_str, _)) = task_info.split_once('|') {
-                            match Uuid::parse_str(task_id_str) {
-                                Ok(task_uuid) => {
-                                    let tomorrow = datetime::format_date_with_offset(1);
-                                    match sync_service.update_task_due_date(&task_uuid, Some(&tomorrow)).await {
-                                        Ok(()) => Ok(format!("{}: {}", SUCCESS_TASK_DUE_TOMORROW, task_id_str)),
-                                        Err(e) => Err(format!("{}: {}", ERROR_TASK_DUE_DATE_FAILED, e)),
-                                    }
-                                }
-                                Err(e) => Err(format!("Invalid task UUID: {}", e)),
-                            }
-                        } else {
-                            Err(ERROR_INVALID_DATE_FORMAT.to_string())
-                        }
-                    }
-                    "Set task due next week" => {
-                        // task_info format: "task_id|next_week"
-                        if let Some((task_id_str, _)) = task_info.split_once('|') {
-                            match Uuid::parse_str(task_id_str) {
-                                Ok(task_uuid) => {
-                                    let today = chrono::Local::now().date_naive();
-                                    let next_monday = crate::utils::datetime::next_weekday(today, chrono::Weekday::Mon);
-                                    let next_monday_str = crate::utils::datetime::format_ymd(next_monday);
-                                    match sync_service.update_task_due_date(&task_uuid, Some(&next_monday_str)).await {
-                                        Ok(()) => Ok(format!("{}: {}", SUCCESS_TASK_DUE_MONDAY, task_id_str)),
-                                        Err(e) => Err(format!("{}: {}", ERROR_TASK_DUE_DATE_FAILED, e)),
-                                    }
-                                }
-                                Err(e) => Err(format!("Invalid task UUID: {}", e)),
-                            }
-                        } else {
-                            Err(ERROR_INVALID_DATE_FORMAT.to_string())
-                        }
-                    }
-                    "Set task due weekend" => {
-                        // task_info format: "task_id|weekend"
-                        if let Some((task_id_str, _)) = task_info.split_once('|') {
-                            match Uuid::parse_str(task_id_str) {
-                                Ok(task_uuid) => {
-                                    let today = chrono::Local::now().date_naive();
-                                    let next_saturday =
-                                        crate::utils::datetime::next_weekday(today, chrono::Weekday::Sat);
-                                    let next_saturday_str = crate::utils::datetime::format_ymd(next_saturday);
-                                    match sync_service.update_task_due_date(&task_uuid, Some(&next_saturday_str)).await
-                                    {
-                                        Ok(()) => Ok(format!("{}: {}", SUCCESS_TASK_DUE_SATURDAY, task_id_str)),
-                                        Err(e) => Err(format!("{}: {}", ERROR_TASK_DUE_DATE_FAILED, e)),
-                                    }
-                                }
-                                Err(e) => Err(format!("Invalid task UUID: {}", e)),
-                            }
-                        } else {
-                            Err(ERROR_INVALID_DATE_FORMAT.to_string())
-                        }
-                    }
-                    "Create task" => match unpack_owned(&task_info) {
-                        Ok((project_uuid, content)) => {
-                            let landed = if project_uuid.is_some() {
-                                SUCCESS_TASK_CREATED_PROJECT
-                            } else {
-                                SUCCESS_TASK_CREATED_INBOX
-                            };
-                            match sync_service.create_task(content, project_uuid).await {
-                                Ok(()) => Ok(format!("{}: {}", landed, content)),
-                                Err(e) => Err(format!("{}: {}", ERROR_TASK_CREATE_FAILED, e)),
-                            }
-                        }
-                        Err(e) => Err(format!("Invalid project UUID: {}", e)),
-                    },
-                    "Edit task" => {
-                        // task_info format: "task_id: new_content"
-                        if let Some((task_id_str, content)) = task_info.split_once(": ") {
-                            match Uuid::parse_str(task_id_str) {
-                                Ok(task_uuid) => match sync_service.update_task_content(&task_uuid, content).await {
-                                    Ok(()) => Ok(format!("{}: {}", SUCCESS_TASK_UPDATED, task_id_str)),
-                                    Err(e) => Err(format!("{}: {}", ERROR_TASK_UPDATE_FAILED, e)),
-                                },
-                                Err(e) => Err(format!("Invalid task UUID: {}", e)),
-                            }
-                        } else {
-                            Err(ERROR_INVALID_TASK_EDIT_FORMAT.to_string())
-                        }
-                    }
-                    "Restore task" => match Uuid::parse_str(&task_info) {
-                        Ok(task_uuid) => match sync_service.restore_task(&task_uuid).await {
-                            Ok(()) => Ok(format!("{}: {}", SUCCESS_TASK_RESTORED, task_info)),
-                            Err(e) => Err(format!("{}: {}", ERROR_TASK_RESTORE_FAILED, e)),
-                        },
-                        Err(e) => Err(format!("Invalid task UUID: {}", e)),
-                    },
-                    "Create project" => match unpack_owned(&task_info) {
-                        Ok((parent_uuid, name)) => {
-                            let landed = if parent_uuid.is_some() {
-                                SUCCESS_PROJECT_CREATED_PARENT
-                            } else {
-                                SUCCESS_PROJECT_CREATED_ROOT
-                            };
-                            match sync_service.create_project(name, parent_uuid).await {
-                                Ok(()) => Ok(format!("{}: {}", landed, name)),
-                                Err(e) => Err(format!("{}: {}", ERROR_PROJECT_CREATE_FAILED, e)),
-                            }
-                        }
-                        Err(e) => Err(format!("Invalid parent project UUID: {}", e)),
-                    },
-                    "Delete project" => {
-                        // task_info is a UUID string
-                        match Uuid::parse_str(&task_info) {
-                            Ok(project_uuid) => match sync_service.delete_project(&project_uuid).await {
-                                Ok(()) => Ok(format!("{}: {}", SUCCESS_PROJECT_DELETED, task_info)),
-                                Err(e) => Err(format!("{}: {}", ERROR_PROJECT_DELETE_FAILED, e)),
-                            },
-                            Err(e) => Err(format!("Invalid project UUID: {}", e)),
-                        }
-                    }
-                    "Delete label" => {
-                        // task_info is a UUID string
-                        match Uuid::parse_str(&task_info) {
-                            Ok(label_uuid) => match sync_service.delete_label(&label_uuid).await {
-                                Ok(()) => Ok(format!("{}: {}", SUCCESS_LABEL_DELETED, task_info)),
-                                Err(e) => Err(format!("{}: {}", ERROR_LABEL_DELETE_FAILED, e)),
-                            },
-                            Err(e) => Err(format!("Invalid label UUID: {}", e)),
-                        }
-                    }
-                    "Create label" => match sync_service.create_label(&task_info).await {
-                        Ok(()) => Ok(format!("{}: {}", SUCCESS_LABEL_CREATED, task_info)),
-                        Err(e) => Err(format!("{}: {}", ERROR_LABEL_CREATE_FAILED, e)),
-                    },
-                    "Edit project" => {
-                        // task_info format: "project_id: new_name"
-                        if let Some((project_id_str, name)) = task_info.split_once(": ") {
-                            match Uuid::parse_str(project_id_str) {
-                                Ok(project_uuid) => {
-                                    match sync_service.update_project_content(&project_uuid, name).await {
-                                        Ok(()) => Ok(format!("{}: {}", SUCCESS_PROJECT_UPDATED, project_id_str)),
-                                        Err(e) => Err(format!("{}: {}", ERROR_PROJECT_UPDATE_FAILED, e)),
-                                    }
-                                }
-                                Err(e) => Err(format!("Invalid project UUID: {}", e)),
-                            }
-                        } else {
-                            Err(ERROR_INVALID_PROJECT_EDIT_FORMAT.to_string())
-                        }
-                    }
-                    "Edit label" => {
-                        // task_info format: "label_id: new_name"
-                        if let Some((label_id_str, name)) = task_info.split_once(": ") {
-                            match Uuid::parse_str(label_id_str) {
-                                Ok(label_uuid) => match sync_service.update_label_content(&label_uuid, name).await {
-                                    Ok(()) => Ok(format!("{}: {}", SUCCESS_LABEL_UPDATED, label_id_str)),
-                                    Err(e) => Err(format!("{}: {}", ERROR_LABEL_UPDATE_FAILED, e)),
-                                },
-                                Err(e) => Err(format!("Invalid label UUID: {}", e)),
-                            }
-                        } else {
-                            Err(ERROR_INVALID_LABEL_EDIT_FORMAT.to_string())
-                        }
-                    }
-                    _ => Err(format!("{}: {}", ERROR_UNKNOWN_OPERATION, op_name)),
-                };
-
-                result.map_err(|e: String| anyhow::anyhow!(e))
-            },
+            move || async move { operation.run(sync_service).await.map_err(anyhow::Error::msg) },
             description,
         );
+    }
+
+    fn set_due(&mut self, task: Uuid, when: Due) -> Action {
+        info!("Task: Setting due {:?} for {}", when, self.describe_task(task));
+        self.spawn(Operation::SetDue { task, when });
+        Action::None
+    }
+
+    /// Names a task for the log, from the list already in memory. A log line is not
+    /// worth a trip to storage; an entry the current view never loaded reads as unknown.
+    fn describe_task(&self, uuid: Uuid) -> String {
+        match self.state.tasks.iter().find(|task| task.uuid == uuid) {
+            Some(task) => format!("ID {} '{}'", uuid, task.content),
+            None => format!("ID {} [unknown]", uuid),
+        }
+    }
+
+    fn describe_project(&self, uuid: Uuid) -> String {
+        match self.state.projects.iter().find(|project| project.uuid == uuid) {
+            Some(project) => format!("ID {} '{}'", uuid, project.name),
+            None => format!("ID {} [unknown]", uuid),
+        }
+    }
+
+    fn describe_label(&self, uuid: Uuid) -> String {
+        match self.state.labels.iter().find(|label| label.uuid == uuid) {
+            Some(label) => format!("ID {} '{}'", uuid, label.name),
+            None => format!("ID {} [unknown]", uuid),
+        }
     }
 
     fn update_data_from_sync(&mut self, status: SyncStatus) {

--- a/src/ui/components/dialog_component.rs
+++ b/src/ui/components/dialog_component.rs
@@ -258,7 +258,7 @@ impl DialogComponent {
             }
             Some(DialogType::DeleteConfirmation { item_type, item_uuid }) => match item_type.as_str() {
                 "task" => {
-                    let action = Action::DeleteTask(item_uuid.to_string());
+                    let action = Action::DeleteTask(*item_uuid);
                     self.clear_dialog();
                     action
                 }

--- a/src/ui/components/task_list_component.rs
+++ b/src/ui/components/task_list_component.rs
@@ -557,9 +557,9 @@ impl Component for TaskListComponent {
                 if let Some(task) = self.get_selected_task() {
                     // Smart toggle: restore if deleted/completed, otherwise complete
                     if task.is_deleted || task.is_completed {
-                        Action::RestoreTask(task.uuid.to_string())
+                        Action::RestoreTask(task.uuid)
                     } else {
-                        Action::CompleteTask(task.uuid.to_string())
+                        Action::CompleteTask(task.uuid)
                     }
                 } else {
                     Action::None
@@ -588,7 +588,7 @@ impl Component for TaskListComponent {
                 if let Some(task) = self.get_selected_task() {
                     // If task is already deleted, restore it; otherwise show delete confirmation
                     if task.is_deleted {
-                        Action::RestoreTask(task.uuid.to_string())
+                        Action::RestoreTask(task.uuid)
                     } else {
                         Action::ShowDialog(DialogType::DeleteConfirmation {
                             item_type: "task".to_string(),
@@ -601,7 +601,7 @@ impl Component for TaskListComponent {
             }
             KeyCode::Char('p') => {
                 if let Some(task) = self.get_selected_task() {
-                    Action::CyclePriority(task.uuid.to_string())
+                    Action::CyclePriority(task.uuid)
                 } else {
                     Action::None
                 }

--- a/src/ui/core/actions.rs
+++ b/src/ui/core/actions.rs
@@ -20,9 +20,9 @@ pub enum Action {
     PreviousTask,
 
     // Task operations
-    CompleteTask(String),
-    DeleteTask(String),
-    CyclePriority(String),
+    CompleteTask(Uuid),
+    DeleteTask(Uuid),
+    CyclePriority(Uuid),
     SetTaskDueToday(Uuid),
     SetTaskDueTomorrow(Uuid),
     SetTaskDueNextWeek(Uuid),
@@ -35,7 +35,7 @@ pub enum Action {
         task_uuid: Uuid,
         content: String,
     },
-    RestoreTask(String),
+    RestoreTask(Uuid),
 
     // Project operations
     CreateProject {

--- a/src/ui/core/operations.rs
+++ b/src/ui/core/operations.rs
@@ -1,31 +1,171 @@
-//! Argument encoding for background operations.
+//! The background operations the UI can ask for.
 //!
-//! Background operations are dispatched by name, with their arguments squeezed into a
-//! single string. Wherever that string carries free-form user text next to a uuid, the
-//! uuid has to come first: a uuid can never contain the separator, so whatever
-//! punctuation the user typed survives the round trip.
+//! Every operation is a value carrying exactly the arguments it needs, so a caller
+//! cannot ask for one that does not exist, forget an argument, or hand over user text
+//! that has to survive a round trip through a delimiter.
 
+use crate::constants::*;
+use crate::sync::SyncService;
+use crate::utils::datetime;
 use uuid::Uuid;
 
-/// Separator between a uuid and the free text that follows it.
-const SEP: char = '|';
+/// The due dates a key binding can set. Todoist takes a plain date string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Due {
+    Today,
+    Tomorrow,
+    NextWeek,
+    Weekend,
+}
 
-/// Packs an optional owner uuid ahead of free-form text. The empty prefix means "no
-/// owner", which is why the separator is always written.
-#[must_use]
-pub fn pack_owned(owner: Option<Uuid>, text: &str) -> String {
-    match owner {
-        Some(uuid) => format!("{uuid}{SEP}{text}"),
-        None => format!("{SEP}{text}"),
+impl Due {
+    /// The date string Todoist expects for this shorthand.
+    #[must_use]
+    pub fn date(self) -> String {
+        let today = chrono::Local::now().date_naive();
+        match self {
+            Due::Today => datetime::format_today(),
+            Due::Tomorrow => datetime::format_date_with_offset(1),
+            Due::NextWeek => datetime::format_ymd(datetime::next_weekday(today, chrono::Weekday::Mon)),
+            Due::Weekend => datetime::format_ymd(datetime::next_weekday(today, chrono::Weekday::Sat)),
+        }
+    }
+
+    /// What to tell the user once the due date lands.
+    #[must_use]
+    pub fn success(self) -> &'static str {
+        match self {
+            Due::Today => SUCCESS_TASK_DUE_TODAY,
+            Due::Tomorrow => SUCCESS_TASK_DUE_TOMORROW,
+            Due::NextWeek => SUCCESS_TASK_DUE_MONDAY,
+            Due::Weekend => SUCCESS_TASK_DUE_SATURDAY,
+        }
     }
 }
 
-/// Splits what [`pack_owned`] produced back apart. The text comes back verbatim,
-/// separators included, because only the first separator is significant.
-pub fn unpack_owned(packed: &str) -> Result<(Option<Uuid>, &str), uuid::Error> {
-    let (owner, text) = packed.split_once(SEP).unwrap_or(("", packed));
-    if owner.is_empty() {
-        return Ok((None, text));
+/// A unit of work to run off the UI thread.
+#[derive(Debug, Clone)]
+pub enum Operation {
+    CompleteTask(Uuid),
+    DeleteTask(Uuid),
+    RestoreTask(Uuid),
+    CyclePriority { task: Uuid, priority: i32 },
+    SetDue { task: Uuid, when: Due },
+    CreateTask { content: String, project: Option<Uuid> },
+    EditTask { task: Uuid, content: String },
+    CreateProject { name: String, parent: Option<Uuid> },
+    EditProject { project: Uuid, name: String },
+    DeleteProject(Uuid),
+    CreateLabel { name: String },
+    EditLabel { label: Uuid, name: String },
+    DeleteLabel(Uuid),
+}
+
+impl Operation {
+    /// What the task manager lists this operation as, and what gets logged when it
+    /// starts. Names the subject rather than the user's text, which can be long.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Operation::CompleteTask(task) => format!("Complete task: {task}"),
+            Operation::DeleteTask(task) => format!("Delete task: {task}"),
+            Operation::RestoreTask(task) => format!("Restore task: {task}"),
+            Operation::CyclePriority { task, priority } => format!("Cycle priority: {task} -> P{priority}"),
+            Operation::SetDue { task, when } => format!("Set task due {when:?}: {task}"),
+            Operation::CreateTask { project, .. } => match project {
+                Some(project) => format!("Create task: in project {project}"),
+                None => "Create task: in inbox".to_string(),
+            },
+            Operation::EditTask { task, .. } => format!("Edit task: {task}"),
+            Operation::CreateProject { parent, .. } => match parent {
+                Some(parent) => format!("Create project: under {parent}"),
+                None => "Create project: at root".to_string(),
+            },
+            Operation::EditProject { project, .. } => format!("Edit project: {project}"),
+            Operation::DeleteProject(project) => format!("Delete project: {project}"),
+            Operation::CreateLabel { name } => format!("Create label: {name}"),
+            Operation::EditLabel { label, .. } => format!("Edit label: {label}"),
+            Operation::DeleteLabel(label) => format!("Delete label: {label}"),
+        }
     }
-    Ok((Some(Uuid::parse_str(owner)?), text))
+
+    /// Runs the operation, reporting either the message to show on success or the one
+    /// to show on failure.
+    pub async fn run(self, sync: SyncService) -> Result<String, String> {
+        fn done(success: &str, subject: impl std::fmt::Display) -> Result<String, String> {
+            Ok(format!("{success}: {subject}"))
+        }
+        fn failed(error: &str, e: impl std::fmt::Display) -> Result<String, String> {
+            Err(format!("{error}: {e}"))
+        }
+
+        match self {
+            Operation::CompleteTask(task) => match sync.complete_task(&task).await {
+                Ok(()) => done(SUCCESS_TASK_COMPLETED, task),
+                Err(e) => failed(ERROR_TASK_COMPLETION_FAILED, e),
+            },
+            Operation::DeleteTask(task) => match sync.delete_task(&task).await {
+                Ok(()) => done(SUCCESS_TASK_DELETED, task),
+                Err(e) => failed(ERROR_TASK_DELETE_FAILED, e),
+            },
+            Operation::RestoreTask(task) => match sync.restore_task(&task).await {
+                Ok(()) => done(SUCCESS_TASK_RESTORED, task),
+                Err(e) => failed(ERROR_TASK_RESTORE_FAILED, e),
+            },
+            Operation::CyclePriority { task, priority } => match sync.update_task_priority(&task, priority).await {
+                Ok(()) => Ok(format!("{SUCCESS_TASK_PRIORITY_UPDATED}{priority}: {task}")),
+                Err(e) => failed(ERROR_TASK_PRIORITY_FAILED, e),
+            },
+            Operation::SetDue { task, when } => match sync.update_task_due_date(&task, Some(&when.date())).await {
+                Ok(()) => done(when.success(), task),
+                Err(e) => failed(ERROR_TASK_DUE_DATE_FAILED, e),
+            },
+            Operation::CreateTask { content, project } => {
+                let landed = if project.is_some() {
+                    SUCCESS_TASK_CREATED_PROJECT
+                } else {
+                    SUCCESS_TASK_CREATED_INBOX
+                };
+                match sync.create_task(&content, project).await {
+                    Ok(()) => done(landed, content),
+                    Err(e) => failed(ERROR_TASK_CREATE_FAILED, e),
+                }
+            }
+            Operation::EditTask { task, content } => match sync.update_task_content(&task, &content).await {
+                Ok(()) => done(SUCCESS_TASK_UPDATED, task),
+                Err(e) => failed(ERROR_TASK_UPDATE_FAILED, e),
+            },
+            Operation::CreateProject { name, parent } => {
+                let landed = if parent.is_some() {
+                    SUCCESS_PROJECT_CREATED_PARENT
+                } else {
+                    SUCCESS_PROJECT_CREATED_ROOT
+                };
+                match sync.create_project(&name, parent).await {
+                    Ok(()) => done(landed, name),
+                    Err(e) => failed(ERROR_PROJECT_CREATE_FAILED, e),
+                }
+            }
+            Operation::EditProject { project, name } => match sync.update_project_content(&project, &name).await {
+                Ok(()) => done(SUCCESS_PROJECT_UPDATED, project),
+                Err(e) => failed(ERROR_PROJECT_UPDATE_FAILED, e),
+            },
+            Operation::DeleteProject(project) => match sync.delete_project(&project).await {
+                Ok(()) => done(SUCCESS_PROJECT_DELETED, project),
+                Err(e) => failed(ERROR_PROJECT_DELETE_FAILED, e),
+            },
+            Operation::CreateLabel { name } => match sync.create_label(&name).await {
+                Ok(()) => done(SUCCESS_LABEL_CREATED, name),
+                Err(e) => failed(ERROR_LABEL_CREATE_FAILED, e),
+            },
+            Operation::EditLabel { label, name } => match sync.update_label_content(&label, &name).await {
+                Ok(()) => done(SUCCESS_LABEL_UPDATED, label),
+                Err(e) => failed(ERROR_LABEL_UPDATE_FAILED, e),
+            },
+            Operation::DeleteLabel(label) => match sync.delete_label(&label).await {
+                Ok(()) => done(SUCCESS_LABEL_DELETED, label),
+                Err(e) => failed(ERROR_LABEL_DELETE_FAILED, e),
+            },
+        }
+    }
 }

--- a/tests/ui/core/operations.rs
+++ b/tests/ui/core/operations.rs
@@ -1,37 +1,37 @@
-//! The encoding that carries an optional owner uuid next to free-form user text.
-//! User text is the untrusted half here, so the separator has to survive inside it.
+//! The one piece of real logic in the operations module: turning a due-date shorthand
+//! into a date. The rest of an Operation is data the type system carries for us.
 
-use terminalist::ui::core::operations::{pack_owned, unpack_owned};
-use uuid::Uuid;
+use chrono::{Datelike, NaiveDate, Weekday};
+use terminalist::ui::core::operations::Due;
+use terminalist::utils::datetime;
 
-/// A pipe in the user's text used to eat the uuid and break creation outright.
-#[test]
-fn text_keeps_its_separators() {
-    let owner = Uuid::new_v4();
-    for text in [
-        "review PR | urgent",
-        "|leading",
-        "trailing|",
-        "a|b|c|d",
-        "|||",
-        "",
-        "plain text",
-        "name: with a colon",
-    ] {
-        let owned = pack_owned(Some(owner), text);
-        let (got_owner, got_text) = unpack_owned(&owned).unwrap();
-        assert_eq!(got_owner, Some(owner), "owner lost for {text:?}");
-        assert_eq!(got_text, text, "text mangled for {text:?}");
-
-        let ownerless = pack_owned(None, text);
-        let (no_owner, got_text) = unpack_owned(&ownerless).unwrap();
-        assert_eq!(no_owner, None, "phantom owner for {text:?}");
-        assert_eq!(got_text, text, "text mangled for {text:?}");
-    }
+fn parse(due: Due) -> NaiveDate {
+    NaiveDate::parse_from_str(&due.date(), "%Y-%m-%d").unwrap_or_else(|e| panic!("{due:?} gave {:?}: {e}", due.date()))
 }
 
-/// A garbled uuid has to surface as an error, not as a silently ownerless item.
 #[test]
-fn a_bad_owner_uuid_is_an_error() {
-    assert!(unpack_owned("not-a-uuid|some text").is_err());
+fn today_and_tomorrow_match_the_shared_date_helpers() {
+    assert_eq!(Due::Today.date(), datetime::format_today());
+    assert_eq!(Due::Tomorrow.date(), datetime::format_date_with_offset(1));
+    assert_eq!(parse(Due::Tomorrow), parse(Due::Today).succ_opt().unwrap());
+}
+
+/// Next week means Monday and the weekend means Saturday. A swap between the two would
+/// otherwise be invisible: both are plausible dates a few days out.
+#[test]
+fn next_week_lands_on_monday_and_the_weekend_on_saturday() {
+    assert_eq!(parse(Due::NextWeek).weekday(), Weekday::Mon);
+    assert_eq!(parse(Due::Weekend).weekday(), Weekday::Sat);
+    assert!(parse(Due::NextWeek) >= parse(Due::Today));
+    assert!(parse(Due::Weekend) >= parse(Due::Today));
+}
+
+/// Four shorthands, four distinct confirmation messages.
+#[test]
+fn every_due_shorthand_has_its_own_message() {
+    let messages = [Due::Today, Due::Tomorrow, Due::NextWeek, Due::Weekend].map(Due::success);
+    let mut unique = messages.to_vec();
+    unique.sort_unstable();
+    unique.dedup();
+    assert_eq!(unique.len(), messages.len(), "duplicate message in {messages:?}");
 }


### PR DESCRIPTION
Background operations were dispatched by name, with their arguments squeezed into a single string that each handler took apart again in three incompatible shapes (`"<uuid>"`, `"<uuid>|today"`, `"<uuid>: <content>"`); a misspelled name compiled fine and failed at runtime on an unknown-operation arm, and that encoding was a live bug until #223. `Operation` is now a value carrying exactly the arguments each case needs and `Operation::run` does the work, so `Uuid::parse_str` disappears from dispatch entirely, the four `Action` variants that carried stringified uuids now carry `Uuid` like their neighbours already did, the four `SetTaskDue*` cases collapse into one `SetDue` plus a `Due` enum owning the date arithmetic, and seven `ERROR_INVALID_*_FORMAT` / `ERROR_UNKNOWN_OPERATION` constants are deleted because nothing can report a malformed encoding or an unknown name any more. Five arms were also reading a task from storage only to put its title in a log line, and now read the list already in memory, saying `[unknown]` when it is absent exactly as the project and label arms already did. `handle_app_action` goes 407 → 312 lines and `mod.rs` 1074 → 786, net −145.

Behaviour is otherwise unchanged, deliberately: `CompleteTask` still reads storage first and declines to send anything for a task it does not find. That silently does nothing at all from the user's point of view, no toast and no feedback, which is worth fixing but not inside a refactor, so it keeps a comment instead.

The pipe round-trip test from #223 is replaced rather than dropped: the encoding it guarded no longer exists and the compiler enforces that property now, so the new tests cover `Due`, which is the real remaining logic (a Monday/Saturday swap there would otherwise be invisible).
