### PR TITLE
fix(ui): stop dropping tasks whose section is not loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Pipes in task and project names** - Creating a task or project whose text contained a `|` failed outright, because the name and the parent id were packed into one string that got split on the first separator. The id now comes first, so your text keeps whatever you typed.
 
+- **Tasks vanishing from a project view** - A task whose section was not among the ones loaded for the project, which happens on a torn read across a sync or when the section belongs to another project, was filed under a bucket the renderer never visits and simply disappeared. Those tasks now show alongside the ones with no section at all.
+
 ### Security
 - **Cache file permissions** - The local SQLite cache stores the Todoist API token, and is now created with `0600` so only its owner can read it. Existing cache files are tightened on the next launch.
 

--- a/src/ui/components/task_list_component.rs
+++ b/src/ui/components/task_list_component.rs
@@ -284,7 +284,7 @@ impl TaskListComponent {
     /// Build items for Project view (with section headers)
     fn build_project_items(&mut self, project_id: &Uuid) {
         use crate::ui::components::task_list_item_component::{HeaderItem, SeparatorItem};
-        use std::collections::HashMap;
+        use std::collections::{HashMap, HashSet};
 
         // Get sections for the current project
         let project_sections: Vec<_> = self
@@ -293,16 +293,20 @@ impl TaskListComponent {
             .filter(|section| &section.project_uuid == project_id)
             .cloned()
             .collect();
+        let known_sections: HashSet<Uuid> = project_sections.iter().map(|section| section.uuid).collect();
 
-        // Group tasks by section (only root tasks - subtasks will be added recursively)
+        // Group tasks by section (only root tasks - subtasks will be added recursively).
+        // A task pointing at a section we don't have (torn read across a sync, or a section
+        // belonging to another project) falls back to the no-section bucket so it stays visible.
         let mut tasks_by_section: HashMap<Option<Uuid>, Vec<task::Model>> = HashMap::new();
         for task in self.tasks.iter().filter(|t| t.parent_uuid.is_none()) {
             if &task.project_uuid == project_id {
-                tasks_by_section.entry(task.section_uuid).or_default().push(task.clone());
+                let key = task.section_uuid.filter(|uuid| known_sections.contains(uuid));
+                tasks_by_section.entry(key).or_default().push(task.clone());
             }
         }
 
-        // Add tasks without sections first
+        // Add tasks without a resolvable section first
         if let Some(tasks_without_section) = tasks_by_section.get(&None) {
             for task in tasks_without_section {
                 self.add_task_and_children_to_items(task.clone(), 0);

--- a/tests/ui/components/task_list_component.rs
+++ b/tests/ui/components/task_list_component.rs
@@ -1,7 +1,102 @@
+use terminalist::entities::{project, section, task};
+use terminalist::ui::components::task_list_item_component::TaskListItemType;
 use terminalist::ui::components::TaskListComponent;
+use terminalist::ui::core::SidebarSelection;
+use uuid::Uuid;
 
 #[test]
 fn test_task_list_component_creation() {
     // Test that TaskListComponent can be created without panicking
     let _task_list = TaskListComponent::new();
+}
+
+fn project_model(uuid: Uuid) -> project::Model {
+    project::Model {
+        uuid,
+        backend_uuid: Uuid::nil(),
+        remote_id: "p1".to_string(),
+        name: "Project".to_string(),
+        is_favorite: false,
+        is_inbox_project: false,
+        order_index: 0,
+        parent_uuid: None,
+    }
+}
+
+fn section_model(uuid: Uuid, project_uuid: Uuid) -> section::Model {
+    section::Model {
+        uuid,
+        backend_uuid: Uuid::nil(),
+        remote_id: "s1".to_string(),
+        name: "Section".to_string(),
+        project_uuid,
+        order_index: 0,
+    }
+}
+
+fn task_model(project_uuid: Uuid, section_uuid: Option<Uuid>, content: &str) -> task::Model {
+    task::Model {
+        uuid: Uuid::new_v4(),
+        backend_uuid: Uuid::nil(),
+        remote_id: content.to_string(),
+        content: content.to_string(),
+        description: None,
+        project_uuid,
+        section_uuid,
+        parent_uuid: None,
+        priority: 1,
+        order_index: 0,
+        due_date: None,
+        due_datetime: None,
+        is_recurring: false,
+        deadline: None,
+        duration: None,
+        is_completed: false,
+        is_deleted: false,
+    }
+}
+
+fn rendered_task_contents(component: &TaskListComponent) -> Vec<String> {
+    component
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            TaskListItemType::Task(task_item) => Some(task_item.task.content.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// A task pointing at a section we don't have loaded must still be rendered, not swallowed.
+/// Happens on a torn read between the sections query and the tasks query across a sync commit,
+/// or when a task's section belongs to another project.
+#[test]
+fn test_tasks_with_unknown_section_are_still_rendered() {
+    let project_uuid = Uuid::new_v4();
+    let known_section = Uuid::new_v4();
+    let other_project_section = Uuid::new_v4();
+
+    let mut component = TaskListComponent::new();
+    component.update_data(
+        vec![
+            task_model(project_uuid, None, "loose"),
+            task_model(project_uuid, Some(known_section), "in known section"),
+            task_model(project_uuid, Some(Uuid::new_v4()), "section not loaded"),
+            task_model(project_uuid, Some(other_project_section), "section of another project"),
+        ],
+        vec![
+            section_model(known_section, project_uuid),
+            section_model(other_project_section, Uuid::new_v4()),
+        ],
+        vec![project_model(project_uuid)],
+        Vec::new(),
+        SidebarSelection::Project(0),
+    );
+
+    let mut rendered = rendered_task_contents(&component);
+    rendered.sort();
+    assert_eq!(
+        rendered,
+        vec!["in known section", "loose", "section not loaded", "section of another project",]
+    );
 }


### PR DESCRIPTION
`build_project_items` grouped a project's root tasks by `section_uuid` and then rendered by walking the sections it had loaded for that project, so a task pointing at any other section landed in a bucket that walk never visits and was silently absent from the view: no error, no placeholder, just a missing task. That happens on a torn read between the sections query and the tasks query across a sync commit, and whenever a task's section belongs to a different project. Sections the view does not know about now resolve to no section at all, so those tasks render with the other section-less ones. The test builds a project holding four tasks, two of them pointing at sections the view has not loaded, and asserts all four come back; without the fix it reports `["in known section", "loose"]` against the expected four, which is exactly the silent drop.
