### PR TITLE
refactor(ui): tag background tasks with a kind instead of sniffing their text

### DIFF
--- a/src/ui/app_component/mod.rs
+++ b/src/ui/app_component/mod.rs
@@ -541,12 +541,14 @@ impl AppComponent {
     /// Spawn a generic task operation (now with actual API calls and data refresh)
     /// Hands an operation to the background task manager.
     fn spawn(&mut self, operation: Operation) {
-        let description = operation.describe();
-        info!("Background: Spawning task operation '{}'", description);
+        info!("Background: Spawning task operation '{}'", operation.describe());
+        // Deleting the project being viewed would leave the sidebar pointing at nothing.
+        let on_success = matches!(operation, Operation::DeleteProject(_))
+            .then_some(Action::NavigateToSidebar(SidebarSelection::Today));
         let sync_service = self.sync_service.clone();
         let _task_id = self.task_manager.spawn_task_operation(
             move || async move { operation.run(sync_service).await.map_err(anyhow::Error::msg) },
-            description,
+            on_success,
         );
     }
 

--- a/src/ui/core/mod.rs
+++ b/src/ui/core/mod.rs
@@ -35,4 +35,4 @@ pub mod task_manager;
 pub use actions::{Action, DialogType, SidebarSelection};
 pub use component::Component;
 pub use event_handler::{EventHandler, EventType};
-pub use task_manager::{TaskId, TaskManager, TaskResult};
+pub use task_manager::{TaskId, TaskKind, TaskManager, TaskResult};

--- a/src/ui/core/task_manager.rs
+++ b/src/ui/core/task_manager.rs
@@ -1,5 +1,4 @@
 use super::actions::{Action, SidebarSelection};
-use crate::constants::UI_LOADING_DATA_FROM_STORAGE;
 use crate::sync::{SyncService, SyncStatus};
 use std::collections::HashMap;
 use tokio::sync::mpsc;
@@ -7,12 +6,22 @@ use tokio::task::JoinHandle;
 
 pub type TaskId = u64;
 
+/// What a background task is doing. The UI asks about kinds rather than matching on a
+/// human-readable description, which user text can imitate: a label or a search query
+/// containing "sync" used to read as a sync in progress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskKind {
+    Sync,
+    DataLoad,
+    Search,
+    Operation,
+}
+
 #[derive(Debug)]
 pub struct BackgroundTask {
     pub id: TaskId,
     pub handle: JoinHandle<anyhow::Result<TaskResult>>,
-    pub description: String,
-    pub started_at: std::time::Instant,
+    pub kind: TaskKind,
 }
 
 #[derive(Debug, Clone)]
@@ -59,7 +68,6 @@ impl TaskManager {
         self.next_task_id += 1;
 
         let action_sender = self.action_sender.clone();
-        let description = "Background sync".to_string();
 
         let handle = tokio::spawn(async move {
             // Send sync started notification
@@ -80,19 +88,14 @@ impl TaskManager {
             }
         });
 
-        let task = BackgroundTask {
-            id: task_id,
-            handle,
-            description,
-            started_at: std::time::Instant::now(),
-        };
-
-        self.tasks.insert(task_id, task);
+        self.insert(task_id, handle, TaskKind::Sync);
         task_id
     }
 
     /// Spawn a background task operation (create, update, delete)
-    pub fn spawn_task_operation<F, Fut>(&mut self, operation: F, description: String) -> TaskId
+    /// `on_success` is sent after the operation succeeds, for the caller to steer the UI
+    /// afterwards, such as leaving a project view whose project has just been deleted.
+    pub fn spawn_task_operation<F, Fut>(&mut self, operation: F, on_success: Option<Action>) -> TaskId
     where
         F: FnOnce() -> Fut + Send + 'static,
         Fut: std::future::Future<Output = anyhow::Result<String>> + Send + 'static,
@@ -101,8 +104,6 @@ impl TaskManager {
         self.next_task_id += 1;
 
         let action_sender = self.action_sender.clone();
-        let desc_clone = description.clone();
-        let desc_for_task = description.clone();
 
         let handle = tokio::spawn(async move {
             match operation().await {
@@ -111,9 +112,8 @@ impl TaskManager {
                     // Send refresh action to update UI with latest data from database
                     let _ = action_sender.send(Action::RefreshData);
 
-                    // For project deletion, navigate to Today view to avoid empty selection
-                    if desc_clone.starts_with("Delete project") {
-                        let _ = action_sender.send(Action::NavigateToSidebar(SidebarSelection::Today));
+                    if let Some(action) = on_success {
+                        let _ = action_sender.send(action);
                     }
 
                     Ok(result)
@@ -129,14 +129,7 @@ impl TaskManager {
             }
         });
 
-        let task = BackgroundTask {
-            id: task_id,
-            handle,
-            description: desc_for_task,
-            started_at: std::time::Instant::now(),
-        };
-
-        self.tasks.insert(task_id, task);
+        self.insert(task_id, handle, TaskKind::Operation);
         task_id
     }
 
@@ -165,7 +158,7 @@ impl TaskManager {
 
     /// Check if any sync tasks are currently running
     pub fn is_syncing(&self) -> bool {
-        self.tasks.values().any(|task| task.description.contains("sync"))
+        self.tasks.values().any(|task| task.kind == TaskKind::Sync)
     }
 
     /// Cancel all running tasks
@@ -186,7 +179,6 @@ impl TaskManager {
         self.next_task_id += 1;
 
         let action_sender = self.action_sender.clone();
-        let description = UI_LOADING_DATA_FROM_STORAGE.to_string();
 
         let handle = tokio::spawn(async move {
             match (
@@ -252,14 +244,7 @@ impl TaskManager {
             }
         });
 
-        let task = BackgroundTask {
-            id: task_id,
-            handle,
-            description,
-            started_at: std::time::Instant::now(),
-        };
-
-        self.tasks.insert(task_id, task);
+        self.insert(task_id, handle, TaskKind::DataLoad);
         task_id
     }
 
@@ -269,7 +254,6 @@ impl TaskManager {
         self.next_task_id += 1;
 
         let action_sender = self.action_sender.clone();
-        let description = format!("Searching tasks: '{}'", query);
 
         let handle = tokio::spawn(async move {
             match sync_service.search_tasks(&query).await {
@@ -291,15 +275,12 @@ impl TaskManager {
             }
         });
 
-        let task = BackgroundTask {
-            id: task_id,
-            handle,
-            description,
-            started_at: std::time::Instant::now(),
-        };
-
-        self.tasks.insert(task_id, task);
+        self.insert(task_id, handle, TaskKind::Search);
         task_id
+    }
+
+    fn insert(&mut self, id: TaskId, handle: JoinHandle<anyhow::Result<TaskResult>>, kind: TaskKind) {
+        self.tasks.insert(id, BackgroundTask { id, handle, kind });
     }
 }
 

--- a/tests/ui/core/task_manager.rs
+++ b/tests/ui/core/task_manager.rs
@@ -5,3 +5,21 @@ fn test_task_manager_creation() {
     // Test that TaskManager can be created without panicking
     let _task_manager = TaskManager::new();
 }
+
+/// is_syncing used to ask whether a task's description contained "sync", so anything the
+/// user could name tripped it: a label called "sync", a search for "sync". Only a real
+/// sync counts now, and these operations must not be mistaken for one.
+#[tokio::test]
+async fn operations_are_never_mistaken_for_a_sync() {
+    let (mut manager, _actions) = TaskManager::new();
+    assert!(!manager.is_syncing(), "a fresh manager is not syncing");
+
+    for label in ["sync", "resync my notes", "Background sync"] {
+        manager.spawn_task_operation(move || async move { Ok(format!("Create label: {label}")) }, None);
+    }
+
+    assert!(
+        !manager.is_syncing(),
+        "operations named after syncing are still not a sync"
+    );
+}


### PR DESCRIPTION
`TaskManager` decided two things by substring-matching human-readable strings that user text can imitate. `is_syncing()` asked whether a task's description contained `"sync"`, so a label named `sync` or a search for `sync` read as a sync in progress and painted the spinner toast until the operation finished; and after a successful operation it checked whether the description started with `"Delete project"` to decide whether to navigate away, which worked only because `Operation::describe()` happens to emit that wording, and would have broken silently the moment #227 reworded it, with no test to catch it. A `BackgroundTask` now carries a `TaskKind` and `is_syncing()` asks for `TaskKind::Sync`, which only `spawn_sync` produces; that is exactly what the old check was reaching for, since none of the other three descriptions contain `"sync"` unless user text puts it there, so nothing changes beyond closing the accidental paths. The navigation becomes an `on_success` action passed in by the caller, leaving `app_component` to decide where the UI goes rather than the task manager guessing from a label. With nothing left to sniff, `BackgroundTask::description` has no readers and is gone along with the `description` argument to `spawn_task_operation` (the caller had already logged it), and `started_at` goes too since nothing ever read it: −45/+26 in `task_manager.rs`.

The new test spawns operations named `"sync"`, `"resync my notes"` and `"Background sync"` and asserts none of them reads as a sync; mis-tagging operations as `TaskKind::Sync` makes it fail, so it is checking the thing it claims to.
