### PR TITLE
fix(ui): stop mislabelling a sync as something else for its whole duration

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -53,7 +53,6 @@ pub const CONFIG_GENERATED: &str = "✅ Generated default configuration file";
 pub const UI_CANNOT_DELETE_TODAY_VIEW: &str = "Cannot delete the Today view";
 pub const UI_NO_TASK_SELECTED_DUE_DATE: &str = "No task selected to set due date";
 pub const UI_LOADING_DATA: &str = "Loading data";
-pub const UI_SYNCING_WITH_TODOIST: &str = "Syncing with Todoist";
 pub const UI_LOADING_DATA_FROM_STORAGE: &str = "Loading data from storage";
 
 /// How long a success toast lingers before it fades on its own.

--- a/src/ui/app_component/mod.rs
+++ b/src/ui/app_component/mod.rs
@@ -761,14 +761,11 @@ impl Component for AppComponent {
         }
         self.task_list.render(f, main_chunks[1]);
 
-        // An in-flight sync outranks whatever the last one left behind.
+        // Work in flight outranks whatever the last operation left behind. state.loading
+        // covers a sync from the moment StartSync is handled; is_syncing() covers the two
+        // frames either side of that, before the action lands and after it clears.
         if self.state.loading || self.is_syncing() {
-            let title = if self.state.loading {
-                UI_LOADING_DATA
-            } else {
-                UI_SYNCING_WITH_TODOIST
-            };
-            Toast::spinner(title, &self.config.theme).render(f, main_chunks[1]);
+            Toast::spinner(UI_LOADING_DATA, &self.config.theme).render(f, main_chunks[1]);
         } else if let Some(toast) = &self.toast {
             toast.render(f, main_chunks[1]);
         }


### PR DESCRIPTION
The spinner chose its title with `if state.loading { "Loading data" } else { "Syncing with Todoist" }`, but `state.loading` is set true the moment `Action::StartSync` is handled and false again on `SyncCompleted`, so a real sync spent its entire life labelled "Loading data" and `UI_SYNCING_WITH_TODOIST` only surfaced in the two transient windows either side of it: after `spawn_sync` but before the `StartSync` action it sends is processed on the next tick, and after the sync completes but before `cleanup_finished_tasks` removes the finished task. Both branches now say "Loading data", which is what was actually on screen for essentially the whole operation, and `UI_SYNCING_WITH_TODOIST` is deleted since nothing reads it any more. `is_syncing()` stays in the condition because it is what holds the spinner up across those two windows; only the label collapses.
