### PR TITLE
refactor(ui): resolve the sidebar selection once for both 'D' and 'E'

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -50,7 +50,6 @@ pub const ERROR_TASK_RESTORE_FAILED: &str = "❌ Failed to restore task";
 
 // UI Messages
 pub const CONFIG_GENERATED: &str = "✅ Generated default configuration file";
-pub const UI_CANNOT_DELETE_TODAY_VIEW: &str = "Cannot delete the Today view";
 pub const UI_NO_TASK_SELECTED_DUE_DATE: &str = "No task selected to set due date";
 pub const UI_LOADING_DATA: &str = "Loading data";
 pub const UI_LOADING_DATA_FROM_STORAGE: &str = "Loading data from storage";

--- a/src/ui/app_component/keys.rs
+++ b/src/ui/app_component/keys.rs
@@ -2,13 +2,40 @@
 //! and the task list have each had their turn in `handle_event`.
 
 use super::AppComponent;
-use crate::constants::{UI_CANNOT_DELETE_TODAY_VIEW, UI_NO_TASK_SELECTED_DUE_DATE};
+use crate::constants::UI_NO_TASK_SELECTED_DUE_DATE;
+use crate::entities::{label, project};
 use crate::ui::core::actions::{Action, DialogType};
 use crate::ui::core::SidebarSelection;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use log::info;
 
+/// What the sidebar is pointing at, resolved to the item itself. Both 'D' and 'E' need
+/// the same five-way answer and differ only in what they do with it.
+enum Selected<'a> {
+    Project(&'a project::Model),
+    Label(&'a label::Model),
+    /// A built-in view, named as it appears in "Cannot delete the {} view".
+    View(&'static str),
+    /// A project or label slot whose index no longer resolves. Names which one.
+    Missing(&'static str),
+}
+
 impl AppComponent {
+    fn selected(&self) -> Selected<'_> {
+        match &self.state.sidebar_selection {
+            SidebarSelection::Today => Selected::View("Today"),
+            SidebarSelection::Tomorrow => Selected::View("Tomorrow"),
+            SidebarSelection::Upcoming => Selected::View("Upcoming"),
+            SidebarSelection::Project(index) => match self.state.projects.get(*index) {
+                Some(project) => Selected::Project(project),
+                None => Selected::Missing("project"),
+            },
+            SidebarSelection::Label(index) => match self.state.labels.get(*index) {
+                Some(label) => Selected::Label(label),
+                None => Selected::Missing("label"),
+            },
+        }
+    }
     pub(super) fn handle_global_key(&mut self, key: KeyEvent) -> Action {
         // Handle help panel scrolling when help is open
         if self.state.show_help {
@@ -47,94 +74,60 @@ impl AppComponent {
                 info!("Global key: 'A' - opening project creation dialog");
                 Action::ShowDialog(DialogType::ProjectCreation)
             }
-            KeyCode::Char('D') => {
-                // Delete current project (only if a project is selected)
-                match &self.state.sidebar_selection {
-                    SidebarSelection::Project(index) => {
-                        if let Some(project) = self.state.projects.get(*index) {
-                            info!(
-                                "Global key: 'D' - deleting project '{}' (ID: {})",
-                                project.name, project.uuid
-                            );
-                            Action::ShowDialog(DialogType::DeleteConfirmation {
-                                item_type: "project".to_string(),
-                                item_uuid: project.uuid,
-                            })
-                        } else {
-                            info!("Global key: 'D' - no project selected (invalid index)");
-                            Action::ShowDialog(DialogType::Error("No project selected to delete".to_string()))
-                        }
-                    }
-                    SidebarSelection::Today => {
-                        info!("Global key: 'D' - cannot delete Today view");
-                        Action::ShowDialog(DialogType::Info(UI_CANNOT_DELETE_TODAY_VIEW.to_string()))
-                    }
-                    SidebarSelection::Tomorrow => {
-                        info!("Global key: 'D' - cannot delete Tomorrow view");
-                        Action::ShowDialog(DialogType::Info("Cannot delete the Tomorrow view".to_string()))
-                    }
-                    SidebarSelection::Upcoming => {
-                        info!("Global key: 'D' - cannot delete Upcoming view");
-                        Action::ShowDialog(DialogType::Info("Cannot delete the Upcoming view".to_string()))
-                    }
-                    SidebarSelection::Label(index) => {
-                        if let Some(label) = self.state.labels.get(*index) {
-                            info!("Global key: 'D' - deleting label '{}' (ID: {})", label.name, label.uuid);
-                            Action::ShowDialog(DialogType::DeleteConfirmation {
-                                item_type: "label".to_string(),
-                                item_uuid: label.uuid,
-                            })
-                        } else {
-                            info!("Global key: 'D' - no label selected (invalid index)");
-                            Action::ShowDialog(DialogType::Error("No label selected to delete".to_string()))
-                        }
-                    }
+            KeyCode::Char('D') => match self.selected() {
+                Selected::Project(project) => {
+                    info!(
+                        "Global key: 'D' - deleting project '{}' (ID: {})",
+                        project.name, project.uuid
+                    );
+                    Action::ShowDialog(DialogType::DeleteConfirmation {
+                        item_type: "project".to_string(),
+                        item_uuid: project.uuid,
+                    })
                 }
-            }
-            KeyCode::Char('E') => {
-                // Edit current sidebar selection (project or label)
-                match &self.state.sidebar_selection {
-                    SidebarSelection::Project(index) => {
-                        if let Some(project) = self.state.projects.get(*index) {
-                            info!(
-                                "Global key: 'E' - editing project '{}' (ID: {})",
-                                project.name, project.uuid
-                            );
-                            Action::ShowDialog(DialogType::ProjectEdit {
-                                project_uuid: project.uuid,
-                                name: project.name.clone(),
-                            })
-                        } else {
-                            info!("Global key: 'E' - no project selected (invalid index)");
-                            Action::ShowDialog(DialogType::Error("No project selected to edit".to_string()))
-                        }
-                    }
-                    SidebarSelection::Today => {
-                        info!("Global key: 'E' - cannot edit Today view");
-                        Action::ShowDialog(DialogType::Info("Cannot edit the Today view".to_string()))
-                    }
-                    SidebarSelection::Tomorrow => {
-                        info!("Global key: 'E' - cannot edit Tomorrow view");
-                        Action::ShowDialog(DialogType::Info("Cannot edit the Tomorrow view".to_string()))
-                    }
-                    SidebarSelection::Upcoming => {
-                        info!("Global key: 'E' - cannot edit Upcoming view");
-                        Action::ShowDialog(DialogType::Info("Cannot edit the Upcoming view".to_string()))
-                    }
-                    SidebarSelection::Label(index) => {
-                        if let Some(label) = self.state.labels.get(*index) {
-                            info!("Global key: 'E' - editing label '{}' (ID: {})", label.name, label.uuid);
-                            Action::ShowDialog(DialogType::LabelEdit {
-                                label_uuid: label.uuid,
-                                name: label.name.clone(),
-                            })
-                        } else {
-                            info!("Global key: 'E' - no label selected (invalid index)");
-                            Action::ShowDialog(DialogType::Error("No label selected to edit".to_string()))
-                        }
-                    }
+                Selected::Label(label) => {
+                    info!("Global key: 'D' - deleting label '{}' (ID: {})", label.name, label.uuid);
+                    Action::ShowDialog(DialogType::DeleteConfirmation {
+                        item_type: "label".to_string(),
+                        item_uuid: label.uuid,
+                    })
                 }
-            }
+                Selected::View(view) => {
+                    info!("Global key: 'D' - cannot delete {} view", view);
+                    Action::ShowDialog(DialogType::Info(format!("Cannot delete the {view} view")))
+                }
+                Selected::Missing(kind) => {
+                    info!("Global key: 'D' - no {} selected (invalid index)", kind);
+                    Action::ShowDialog(DialogType::Error(format!("No {kind} selected to delete")))
+                }
+            },
+            KeyCode::Char('E') => match self.selected() {
+                Selected::Project(project) => {
+                    info!(
+                        "Global key: 'E' - editing project '{}' (ID: {})",
+                        project.name, project.uuid
+                    );
+                    Action::ShowDialog(DialogType::ProjectEdit {
+                        project_uuid: project.uuid,
+                        name: project.name.clone(),
+                    })
+                }
+                Selected::Label(label) => {
+                    info!("Global key: 'E' - editing label '{}' (ID: {})", label.name, label.uuid);
+                    Action::ShowDialog(DialogType::LabelEdit {
+                        label_uuid: label.uuid,
+                        name: label.name.clone(),
+                    })
+                }
+                Selected::View(view) => {
+                    info!("Global key: 'E' - cannot edit {} view", view);
+                    Action::ShowDialog(DialogType::Info(format!("Cannot edit the {view} view")))
+                }
+                Selected::Missing(kind) => {
+                    info!("Global key: 'E' - no {} selected (invalid index)", kind);
+                    Action::ShowDialog(DialogType::Error(format!("No {kind} selected to edit")))
+                }
+            },
             KeyCode::Char('r') => {
                 info!("Global key: 'r' - starting manual sync");
                 Action::StartSync


### PR DESCRIPTION
Deleting and editing asked the same five-way question about the sidebar selection, each nesting an index lookup inside a match over all five `SidebarSelection` variants, and then differed only in which dialog they built from the answer. A `Selected` enum answers that question once, so both key arms become flat four-case matches: project, label, built-in view, or a slot whose index no longer resolves. The ten user-visible messages are now generated from two templates instead of written out ten times, and I verified they come out byte for byte identical to before. Worth noting only Today's delete message had been a constant while the other nine were inline literals free to drift from it, so `UI_CANNOT_DELETE_TODAY_VIEW` goes too. Net −8 lines, which understates it: the duplicated five-way match is what actually went, and a sixth `SidebarSelection` variant now needs one arm here rather than two.

No test: `handle_global_key` needs a whole `AppComponent` and so a temporary database, which is a lot of scaffolding for an index lookup, and the message-equivalence I cared about is a one-time migration property rather than an invariant worth pinning.
