### PR TITLE
fix(ui): stop the initial sync from stealing the user's sidebar selection

### DIFF
--- a/src/ui/app_component/actions.rs
+++ b/src/ui/app_component/actions.rs
@@ -100,6 +100,9 @@ impl AppComponent {
                 };
 
                 info!("Navigation: Sidebar selection changed to {}", selection_desc);
+                // Once the user has picked a view, the initial sync no longer owns the
+                // selection: completing it must not drag them back to `default_project`.
+                self.is_initial_sync = false;
                 self.state.sidebar_selection = selection.clone();
                 // Reload data for the new selection
                 self.schedule_data_fetch();


### PR DESCRIPTION
## The bug

Navigate to a project before the initial sync finishes and you get yanked to `default_project` the moment it lands. That defeats the point of keeping the cache across restarts: the projects are navigable early, but the sync takes the view back.

## Cause

`trigger_initial_sync` (`app_component/mod.rs:114-127`) sets `is_initial_sync = true`, loads the cached snapshot, and starts the sync. The cached load fires `InitialDataLoaded`, which applies `default_project` and is exactly right at that point. But nothing clears the flag, so when the sync completes `update_data_from_sync` takes the initial branch *again* and re-applies `default_project` over whatever the user picked.

Debug mode dodges it because it flips the flag back immediately (`:117-119`).

The flag predates the persistent cache. It was added in b91e951 to stop a manual refresh bouncing you to the default project, back when the DB was wiped at every launch and the first sync really was the moment the app first had data to select from.

## Fix

Clear `is_initial_sync` in `Action::NavigateToSidebar`. Once the user has picked a view, the sync no longer owns the selection.

Without navigation the flag stays set, so a fresh install with an empty cache still resolves `default_project` after the sync brings the projects in. Inbox is an ordinary project row (`is_inbox_project`), not a built-in view like Today, so it can't be resolved before the first fetch and that second pass still earns its keep.

## Not in scope

- `SidebarSelection::Project(usize)` is positional, so a project deleted from another client slides your selection onto a neighbour instead of redirecting. Wants a uuid-keyed selection, which wants stable local UUIDs first (PR #209 item 1).
- A background sync still moves the task cursor mid-list (PR #209 item 2).

## Testing

`cargo clippy --all-targets` clean, `cargo test` passes. No unit test: asserting this needs an `AppComponent` plus a faked sync round-trip, a lot of fixture for one boolean.